### PR TITLE
[KIT-131] [FE] 게시글 수정

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -8,6 +8,7 @@ import PostMakerContainer from './containers/PostMaker/PostMakerContainer';
 import ProfilePageContainer from './containers/ProfilePage/ProfilePageContainer';
 import SignupPageContainer from './containers/SignupPage/SignupPageContainer';
 import PostWritePage from './pages/PostWritePage';
+import PostUpdatePage from './pages/PostUpdatePage';
 import ReplyUpdatePage from './pages/ReplyUpdatePage';
 
 const BodyContainer = styled.div`
@@ -24,6 +25,11 @@ const Routes = () => (
         exact
         path="/board/:boardNameEng/write"
         component={PostWritePage}
+      />
+      <Route
+        exact
+        path="/board/:boardNameEng/:postId/write"
+        component={PostUpdatePage}
       />
       <Route
         exact

--- a/src/Router.js
+++ b/src/Router.js
@@ -1,15 +1,15 @@
 import React from 'react';
-import { Route, Redirect } from 'react-router-dom';
+import { Route, Redirect, Switch } from 'react-router-dom';
 import styled from 'styled-components';
 import HeaderContainer from './containers/Header/HeaderContainer';
-import BoardContainer from './containers/Board/BoardContainer';
-import PostContainer from './containers/Post/PostContainer';
 import PostMakerContainer from './containers/PostMaker/PostMakerContainer';
 import ProfilePageContainer from './containers/ProfilePage/ProfilePageContainer';
 import SignupPageContainer from './containers/SignupPage/SignupPageContainer';
 import PostWritePage from './pages/PostWritePage';
 import PostUpdatePage from './pages/PostUpdatePage';
 import ReplyUpdatePage from './pages/ReplyUpdatePage';
+import BoardPage from './pages/BoardPage';
+import PostPage from './pages/PostPage';
 
 const BodyContainer = styled.div`
   padding-top: 96px;
@@ -19,32 +19,30 @@ const Routes = () => (
   <>
     <HeaderContainer />
     <BodyContainer>
-      <Route exact path="/profile" component={ProfilePageContainer} />
-      <Route exact path="/signup" component={SignupPageContainer} />
-      <Route
-        exact
-        path="/board/:boardNameEng/write"
-        component={PostWritePage}
-      />
-      <Route
-        exact
-        path="/board/:boardNameEng/:postId/write"
-        component={PostUpdatePage}
-      />
-      <Route
-        exact
-        path="/board/:boardNameEng/:postId/update/:replyId"
-        component={ReplyUpdatePage}
-      />
-      <Route
-        exact
-        path="/board/:boardNameEng/:postId"
-        component={PostContainer}
-      />
-      <Route path="/board/:boardNameEng" component={BoardContainer} />
-      <Route path="/">
-        <Redirect to="/board/freeboard" />
-      </Route>
+      <Switch>
+        <Route exact path="/profile" component={ProfilePageContainer} />
+        <Route exact path="/signup" component={SignupPageContainer} />
+        <Route
+          exact
+          path="/board/:boardNameEng/write"
+          component={PostWritePage}
+        />
+        <Route
+          exact
+          path="/board/:boardNameEng/:postId/write"
+          component={PostUpdatePage}
+        />
+        <Route
+          exact
+          path="/board/:boardNameEng/:postId/update/:replyId"
+          component={ReplyUpdatePage}
+        />
+        <Route exact path="/board/:boardNameEng/:postId" component={PostPage} />
+        <Route exact path="/board/:boardNameEng" component={BoardPage} />
+        <Route path="/">
+          <Redirect to="/board/freeboard" />
+        </Route>
+      </Switch>
     </BodyContainer>
     <PostMakerContainer />
   </>

--- a/src/components/Board/Board.js
+++ b/src/components/Board/Board.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 import {
   faEye,
   faCommentAlt,
@@ -29,22 +29,6 @@ import Tags from '../Post/Tags';
 const LoadingCircle = styled(CircularProgress)`
   position: absolute;
   bottom: 50vh;
-`;
-
-const MainWrapper = styled.div`
-  margin: auto;
-  margin-top: 2rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 70vw;
-  padding: 0 1.5rem;
-  box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
-  @media ${props => props.theme.mobile} {
-    width: calc(100vw - 1rem);
-    margin-top: 1rem;
-    padding: 0.5rem;
-  }
 `;
 
 const NoneBorderCell = styled(TableCell)`
@@ -335,15 +319,11 @@ const Board = props => {
   }
 
   if (data === null || loading) {
-    return (
-      <MainWrapper>
-        <LoadingCircle />
-      </MainWrapper>
-    );
+    return <LoadingCircle />;
   }
   const res = data.data;
   return (
-    <MainWrapper>
+    <>
       <BoardHeader
         boardDescription={boardDescription}
         postSearchType={postSearchType}
@@ -366,7 +346,7 @@ const Board = props => {
           />
         </>
       )}
-    </MainWrapper>
+    </>
   );
 };
 

--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -307,10 +307,10 @@ const Editor = props => {
 
   return (
     <CKEditor
+      data={data}
       editor={ClassicEditor}
       config={config(placeholder)}
       onChange={onChange}
-      data={data}
     />
   );
 };

--- a/src/components/Post/Post.js
+++ b/src/components/Post/Post.js
@@ -11,7 +11,9 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ConditionClassify, menuStorage } from '../../DataExport';
 import ReplyListContainer from '../../containers/Reply/ReplyListContainer';
+import EditorOutput from '../Editor/EditorOutput';
 import Tags from './Tags';
+import { getEncodeHTML } from '../../utils/format';
 
 const LoadingCircle = styled(CircularProgress)`
   position: absolute;
@@ -27,6 +29,7 @@ const MainWrapper = styled.div`
   margin: auto;
   margin-top: 3rem;
   width: 70vw;
+  max-width: 100%;
   padding: 1.5rem;
   display: display;
   align-items: center;
@@ -35,7 +38,7 @@ const MainWrapper = styled.div`
   @media ${props => props.theme.mobile} {
     width: calc(100vw - 1rem);
     margin-top: 1rem;
-    padding: 0.5rem;
+    padding: 0;
   }
 `;
 
@@ -48,8 +51,7 @@ const NoBoardBox = styled.div`
 `;
 
 const PostHead = styled.div`
-  width: 100%;
-  padding-bottom: 1rem;
+  padding: 1rem 0.5rem;
 `;
 
 const PostHeadTitle = styled.div`
@@ -78,7 +80,7 @@ const AnonymousIcon = styled.span`
 `;
 
 const PostText = styled.div`
-  padding: 3rem 2rem;
+  padding: 3rem 0.6em;
   font-size: 1rem;
   border-top: 1px solid #cccccc;
   border-bottom: 1px solid #cccccc;
@@ -273,9 +275,12 @@ const PostHeader = props => {
 const PostMain = props => {
   const { res } = props;
   const { postContent } = res;
+  const handleContent = () => {
+    return { __html: getEncodeHTML(postContent.text) };
+  };
   return (
     <PostText>
-      <p>{postContent.text}</p>
+      <EditorOutput content={handleContent()} />
     </PostText>
   );
 };

--- a/src/components/Post/Post.js
+++ b/src/components/Post/Post.js
@@ -25,23 +25,6 @@ const FormTextField = styled(TextField)`
   min-width: 256px;
 `;
 
-const MainWrapper = styled.div`
-  margin: auto;
-  margin-top: 3rem;
-  width: 70vw;
-  max-width: 100%;
-  padding: 1.5rem;
-  display: display;
-  align-items: center;
-  background-color: #ffffff;
-  box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
-  @media ${props => props.theme.mobile} {
-    width: calc(100vw - 1rem);
-    margin-top: 1rem;
-    padding: 0;
-  }
-`;
-
 const NoBoardBox = styled.div`
   width: 100%;
   height: 100%;
@@ -289,7 +272,7 @@ const SecretPostPassword = props => {
   const { password, PasswordSubmit, onChange } = props;
 
   return (
-    <MainWrapper>
+    <>
       <FormField onSubmit={PasswordSubmit}>
         <FormTextField
           autoFocus
@@ -303,7 +286,7 @@ const SecretPostPassword = props => {
           확인
         </SubmitButton>
       </FormField>
-    </MainWrapper>
+    </>
   );
 };
 
@@ -355,7 +338,7 @@ const Post = props => {
   const res = data.data;
 
   return (
-    <MainWrapper>
+    <>
       <PostHeader
         res={res}
         moremenuEl={moremenuEl}
@@ -366,7 +349,7 @@ const Post = props => {
       />
       <PostMain res={res} />
       <ReplyListContainer replyReportHandle={replyReportHandle} />
-    </MainWrapper>
+    </>
   );
 };
 

--- a/src/components/Post/PostUpdate.js
+++ b/src/components/Post/PostUpdate.js
@@ -95,11 +95,17 @@ const NoticeToggle = props => {
 };
 
 const PostUpdateInput = props => {
-  const { updateForm, handleChange, handleSecret, handleNotice } = props;
+  const {
+    isAccountPost,
+    updateForm,
+    handleChange,
+    handleSecret,
+    handleNotice
+  } = props;
 
   return (
     <InputWrapper>
-      {!localStorage.getItem('token') || !localStorage.getItem('userId') ? (
+      {!isAccountPost ? (
         <InputStyled
           placeholder="비밀번호"
           id="anonymousPassword"
@@ -109,9 +115,7 @@ const PostUpdateInput = props => {
         />
       ) : null}
       <SecretToggle onChange={handleSecret} />
-      {localStorage.getItem('token') && localStorage.getItem('userId') ? (
-        <NoticeToggle onChange={handleNotice} />
-      ) : null}
+      {isAccountPost ? <NoticeToggle onChange={handleNotice} /> : null}
     </InputWrapper>
   );
 };
@@ -155,6 +159,7 @@ const PostUpdateAction = props => {
 };
 const PostUpdateFooter = props => {
   const {
+    isAccountPost,
     updateForm,
     handleChange,
     handleSecret,
@@ -166,6 +171,7 @@ const PostUpdateFooter = props => {
   return (
     <Wrapper>
       <PostUpdateInput
+        isAccountPost={isAccountPost}
         updateForm={updateForm}
         handleChange={handleChange}
         handleSecret={handleSecret}
@@ -190,7 +196,7 @@ const PostUpdate = props => {
   return (
     <>
       <PostTitle {...postTitleProps} />
-      <PostTagAdd {...postTagAddProps} />
+      {postTagAddProps.isAccountPost && <PostTagAdd {...postTagAddProps} />}
       {editorProps.data && <Editor {...editorProps} />}
       <FileAttachDropZone {...fileAttachDropZoneProps} />
       <AttachImageList {...attachImageListProps} />

--- a/src/components/Post/PostUpdate.js
+++ b/src/components/Post/PostUpdate.js
@@ -1,0 +1,206 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Switch, FormControlLabel, Input, Button } from '@material-ui/core';
+import AttachImageList from '../Editor/AttachImageList';
+import AttachList from '../Editor/AttachList';
+import Editor from '../Editor/Editor';
+import FileAttachDropZone from '../FileAttachDropZone/FileAttachDropZone';
+import ErrorMessage from '../Action/ErrorMessage';
+import PostTagAdd from './PostTagAdd';
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  @media ${props => props.theme.mobile} {
+    flex-direction: column;
+    align-items: flex-start;
+    transition: all 3s ease;
+  }
+`;
+
+const TitleInput = styled.input`
+  width: 100%;
+  font-size: 1.5rem;
+  pupdateing: 0;
+  border-width: 0;
+  margin-bottom: 5px;
+  border-bottom: 2px solid #ccc;
+
+  &:focus {
+    outline: none;
+    border-bottom: 2px solid #000;
+  }
+`;
+
+const FormControlLabelStyled = styled(FormControlLabel)`
+  span {
+    font-size: 0.75rem;
+  }
+`;
+
+const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+`;
+
+const InputStyled = styled(Input)`
+  width: 120px;
+  height: 32px;
+  margin-right: 5px;
+  & input {
+    font-size: 0.875rem;
+    pupdateing: 4px 0;
+  }
+`;
+
+const ButtonWrapper = styled.div`
+  @media ${props => props.theme.mobile} {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+  }
+`;
+
+const ButtonStyled = styled(Button)`
+  font-weight: 500;
+  line-height: 1.5;
+  pupdateing: 6px 12px;
+  border-radius: 100px;
+  margin-left: 10px;
+`;
+
+const Toggle = props => {
+  const { id, label, onChange } = props;
+  return (
+    <FormControlLabelStyled
+      control={<Switch color="secondary" id={id} onChange={onChange} />}
+      labelPlacement="start"
+      label={label}
+      size="small"
+      margin="dense"
+    />
+  );
+};
+
+const SecretToggle = props => {
+  const { onChange } = props;
+  return <Toggle id="isSecret" label="비밀글" onChange={onChange} />;
+};
+
+const NoticeToggle = props => {
+  const { onChange } = props;
+  return <Toggle id="isNotice" label="공지" onChange={onChange} />;
+};
+
+const PostUpdateInput = props => {
+  const { updateForm, handleChange, handleSecret, handleNotice } = props;
+
+  return (
+    <InputWrapper>
+      {!localStorage.getItem('token') || !localStorage.getItem('userId') ? (
+        <InputStyled
+          placeholder="비밀번호"
+          id="anonymousPassword"
+          type="password"
+          value={updateForm.anonymousPassword}
+          onChange={handleChange}
+        />
+      ) : null}
+      <SecretToggle onChange={handleSecret} />
+      {localStorage.getItem('token') && localStorage.getItem('userId') ? (
+        <NoticeToggle onChange={handleNotice} />
+      ) : null}
+    </InputWrapper>
+  );
+};
+
+const PostTitle = props => {
+  const { value, onChange } = props;
+  return (
+    <TitleInput
+      id="title"
+      value={value}
+      onChange={onChange}
+      placeholder="제목을 입력하세요"
+      required
+    />
+  );
+};
+
+const PostUpdateAction = props => {
+  const { onSubmit, onCancel } = props;
+  return (
+    <ButtonWrapper>
+      <ButtonStyled
+        variant="contained"
+        color="default"
+        size="small"
+        type="submit"
+        onClick={onCancel}
+      >
+        취소
+      </ButtonStyled>
+      <ButtonStyled
+        variant="contained"
+        color="default"
+        size="small"
+        type="submit"
+        onClick={onSubmit}
+      >
+        작성
+      </ButtonStyled>
+    </ButtonWrapper>
+  );
+};
+const PostUpdateFooter = props => {
+  const {
+    updateForm,
+    handleChange,
+    handleSecret,
+    handleNotice,
+    onSubmit,
+    onCancel
+  } = props;
+
+  return (
+    <Wrapper>
+      <PostUpdateInput
+        updateForm={updateForm}
+        handleChange={handleChange}
+        handleSecret={handleSecret}
+        handleNotice={handleNotice}
+        onSubmit={onSubmit}
+      />
+      <PostUpdateAction onSubmit={onSubmit} onCancel={onCancel} />
+    </Wrapper>
+  );
+};
+
+const PostUpdate = props => {
+  const {
+    postTitleProps,
+    postTagAddProps,
+    editorProps,
+    fileAttachDropZoneProps,
+    attachImageListProps,
+    attachListProps,
+    postUpdateFooterProps,
+    errorMessageProps
+  } = props;
+  return (
+    <>
+      <PostTitle {...postTitleProps} />
+      <PostTagAdd {...postTagAddProps} />
+      <Editor {...editorProps} />
+      <FileAttachDropZone {...fileAttachDropZoneProps} />
+      <AttachImageList {...attachImageListProps} />
+      <AttachList {...attachListProps} />
+      <PostUpdateFooter {...postUpdateFooterProps} />
+      <ErrorMessage {...errorMessageProps} />
+    </>
+  );
+};
+
+export default PostUpdate;

--- a/src/components/Post/PostUpdate.js
+++ b/src/components/Post/PostUpdate.js
@@ -137,7 +137,6 @@ const PostUpdateAction = props => {
         variant="contained"
         color="default"
         size="small"
-        type="submit"
         onClick={onCancel}
       >
         취소
@@ -171,7 +170,6 @@ const PostUpdateFooter = props => {
         handleChange={handleChange}
         handleSecret={handleSecret}
         handleNotice={handleNotice}
-        onSubmit={onSubmit}
       />
       <PostUpdateAction onSubmit={onSubmit} onCancel={onCancel} />
     </Wrapper>
@@ -193,7 +191,7 @@ const PostUpdate = props => {
     <>
       <PostTitle {...postTitleProps} />
       <PostTagAdd {...postTagAddProps} />
-      <Editor {...editorProps} />
+      {editorProps.data && <Editor {...editorProps} />}
       <FileAttachDropZone {...fileAttachDropZoneProps} />
       <AttachImageList {...attachImageListProps} />
       <AttachList {...attachListProps} />

--- a/src/containers/Board/BoardContainer.js
+++ b/src/containers/Board/BoardContainer.js
@@ -13,11 +13,11 @@ const BoardContainer = props => {
   const [boardPage, setBoardPage] = useState(1);
   const [boardDescription, setBoardDescription] = useState('');
   const [postSearchType, setPostSearchType] = useState('TITLE_TEXT');
-  const { data, loading, error, menuList } = useSelector(({ post }) => ({
+  const { data, loading, error, menuList } = useSelector(({ post, menu }) => ({
     data: post.loadedPostList.data,
     loading: post.loadedPostList.loading,
     error: post.loadedPostList.error,
-    menuList: post.loadedMenuList.data
+    menuList: menu.loadedMenuList.data
   }));
 
   const pageSize = 20;
@@ -59,7 +59,7 @@ const BoardContainer = props => {
     };
     dispatch(loadPostList(parameter));
     setBoardPage(page);
-  }, [location.search, boardNameEng, menuList]);
+  }, [location.search]);
 
   const onChange = e => {
     e.preventDefault();

--- a/src/containers/Header/HeaderContainer.js
+++ b/src/containers/Header/HeaderContainer.js
@@ -1,15 +1,15 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { loadMenuList } from '../../modules/post';
+import { loadMenuList } from '../../modules/menu';
 import Header from '../../components/Header/Header';
 
 const HeaderContainer = () => {
   const dispatch = useDispatch();
-  const { data, loading, error } = useSelector(({ post }) => ({
-    data: post.loadedMenuList.data,
-    loading: post.loadedMenuList.loading,
-    error: post.loadedMenuList.error
+  const { data, loading, error } = useSelector(({ menu }) => ({
+    data: menu.loadedMenuList.data,
+    loading: menu.loadedMenuList.loading,
+    error: menu.loadedMenuList.error
   }));
 
   useEffect(() => {

--- a/src/containers/Post/PostAddContainer.js
+++ b/src/containers/Post/PostAddContainer.js
@@ -21,6 +21,7 @@ const PostAddContainer = props => {
   const dispatch = useDispatch();
   const {
     addForm,
+    addData,
     addLoading,
     addError,
     addAttachData,
@@ -32,6 +33,7 @@ const PostAddContainer = props => {
     searchTagError
   } = useSelector(({ post, attach, tag }) => ({
     addForm: post.addForm,
+    addData: post.addPost.data,
     addLoading: post.addPost.loading,
     addError: post.addPost.error,
     addAttachData: attach.addAttach.data,
@@ -217,6 +219,12 @@ const PostAddContainer = props => {
       dispatch(searchTag({ text: searchText }));
     }
   }, [searchText]);
+
+  useEffect(() => {
+    if (addData) {
+      onGoBack();
+    }
+  }, [addData]);
 
   useEffect(() => {
     return onInitialize();

--- a/src/containers/Post/PostAddContainer.js
+++ b/src/containers/Post/PostAddContainer.js
@@ -11,7 +11,7 @@ import {
 import {
   addPost,
   changeField,
-  initializeForm as initializePostForm
+  initialize as initializePost
 } from '../../modules/post';
 import confirmFileExtension from '../../utils/confirmFileExtension';
 import { getDecodeHTML } from '../../utils/format';
@@ -132,7 +132,7 @@ const PostAddContainer = props => {
 
   const onInitialize = () => {
     dispatch(initializeTag());
-    dispatch(initializePostForm());
+    dispatch(initializePost());
   };
 
   const onCancel = () => {
@@ -222,13 +222,10 @@ const PostAddContainer = props => {
 
   useEffect(() => {
     if (addData) {
+      onInitialize();
       onGoBack();
     }
   }, [addData]);
-
-  useEffect(() => {
-    return onInitialize();
-  }, []);
 
   const postTitleProps = {
     value: addForm.title,

--- a/src/containers/Post/PostContainer.js
+++ b/src/containers/Post/PostContainer.js
@@ -16,7 +16,7 @@ import AnonymousDeleteDialog from '../../components/Post/AnonymousDeleteDialog';
 import ReportDialog from '../../components/Post/ReportDialog';
 
 const PostContainer = props => {
-  const { location, match } = props;
+  const { location, match, history } = props;
   const [moremenuEl, setMoremenuEl] = useState(null);
   const [writerEl, setWriterEl] = useState(null);
   const [secretPost, setSecretPost] = useState(false);
@@ -151,6 +151,11 @@ const PostContainer = props => {
     setReportDescription('');
   };
 
+  const updatePostFunction = () => {
+    const { boardNameEng, postId } = match.params;
+    history.push(`/board/${boardNameEng}/${postId}/write`);
+  };
+
   const banFunction = () => {
     console.log('ban logic');
   };
@@ -190,6 +195,9 @@ const PostContainer = props => {
         break;
       case 'post':
         postFunction();
+        break;
+      case 'fix':
+        updatePostFunction();
         break;
       case 'delete':
         deleteBoxHandle();

--- a/src/containers/Post/PostUpdateContainer.js
+++ b/src/containers/Post/PostUpdateContainer.js
@@ -270,6 +270,7 @@ const PostUpdateContainer = props => {
   };
 
   const postTagAddProps = {
+    isAccountPost: loadedPostData ? loadedPostData.data.accountIdString : null,
     value: searchText,
     tagData: updateForm.tagList,
     searchTagData,
@@ -306,6 +307,7 @@ const PostUpdateContainer = props => {
   };
 
   const postUpdateFooterProps = {
+    isAccountPost: loadedPostData ? loadedPostData.data.accountIdString : null,
     updateForm,
     handleChange,
     handleSecret,

--- a/src/containers/Post/PostUpdateContainer.js
+++ b/src/containers/Post/PostUpdateContainer.js
@@ -11,7 +11,7 @@ import {
 import {
   updatePost,
   changeField,
-  initializeForm as initializePostForm,
+  initialize as initializePost,
   loadPost
 } from '../../modules/post';
 import confirmFileExtension from '../../utils/confirmFileExtension';
@@ -123,7 +123,6 @@ const PostUpdateContainer = props => {
     e.preventDefault();
     const { postId } = match.params;
     const {
-      anonymousNickname,
       anonymousPassword,
       isNotice,
       isSecret,
@@ -132,10 +131,8 @@ const PostUpdateContainer = props => {
       tagList,
       attachmentList
     } = updateForm;
-    const anonymous = { anonymousNickname, anonymousPassword };
     const replaceText = getDecodeHTML(text);
     const postContent = { title, text: replaceText };
-    const { boardNameEng } = match.params;
     const attachIdList = attachmentList.map(attach => ({
       attachId: attach.attachId
     }));
@@ -143,9 +140,8 @@ const PostUpdateContainer = props => {
     dispatch(
       updatePost({
         postId,
-        anonymous,
+        anonymousPassword,
         attachmentList: attachIdList,
-        boardNameEng,
         isNotice,
         isSecret,
         postContent,
@@ -155,13 +151,13 @@ const PostUpdateContainer = props => {
   };
 
   const onGoBack = () => {
-    const { boardNameEng, postId } = match.params;
-    history.push(`/board/${boardNameEng}/${postId}`);
+    console.log('aaa');
+    history.goBack();
   };
 
   const onInitialize = () => {
     dispatch(initializeTag());
-    dispatch(initializePostForm());
+    dispatch(initializePost());
   };
 
   const onCancel = () => {
@@ -263,13 +259,10 @@ const PostUpdateContainer = props => {
 
   useEffect(() => {
     if (updateData) {
+      onInitialize();
       onGoBack();
     }
   }, [updateData]);
-
-  useEffect(() => {
-    return onInitialize();
-  }, []);
 
   const postTitleProps = {
     value: updateForm.title,

--- a/src/containers/Post/PostUpdateContainer.js
+++ b/src/containers/Post/PostUpdateContainer.js
@@ -1,0 +1,298 @@
+import React, { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import PostUpdate from '../../components/Post/PostUpdate';
+import { addAttachList } from '../../modules/attach';
+import {
+  searchTag,
+  changeText,
+  initialize as initializeTag
+} from '../../modules/tag';
+import {
+  updatePost,
+  changeField,
+  initializeForm as initializePostForm
+} from '../../modules/post';
+import confirmFileExtension from '../../utils/confirmFileExtension';
+import { getDecodeHTML } from '../../utils/format';
+
+const PostUpdateContainer = props => {
+  const { history, match } = props;
+  const dispatch = useDispatch();
+  const {
+    updateForm,
+    updateLoading,
+    updateError,
+    updateAttachData,
+    attachLoading,
+    attachError,
+    searchText,
+    searchTagData,
+    searchTagLoading,
+    searchTagError
+  } = useSelector(({ post, attach, tag }) => ({
+    updateForm: post.updateForm,
+    updateLoading: post.updatePost.loading,
+    updateError: post.updatePost.error,
+    addAttachData: attach.addAttach.data,
+    attachLoading: attach.addAttach.loading,
+    attachError: attach.addAttach.error,
+    searchText: tag.searchText,
+    searchTagData: tag.searchTag.data,
+    searchTagLoading: tag.searchTag.loading,
+    searchTagError: tag.searchTag.error
+  }));
+  const [tagUpdateMessage, setTagUpdateMessage] = useState('');
+
+  const handlePostForm = (form, key, value) => {
+    dispatch(changeField({ form, key, value }));
+  };
+
+  const handleToggle = (e, values) => {
+    const { id, checked } = e.target;
+    const form = 'updateForm';
+    const key = id;
+    const value = checked ? values[0] : values[1];
+
+    handlePostForm(form, key, value);
+  };
+
+  const handleChange = e => {
+    const { id, value } = e.target;
+    const form = 'updateForm';
+    const key = id;
+
+    handlePostForm(form, key, value);
+  };
+
+  const handleSecret = e => {
+    handleToggle(e, ['SECRET', 'NORMAL']);
+  };
+
+  const handleNotice = e => {
+    handleToggle(e, ['NOTICE', 'NORMAL']);
+  };
+
+  const handleContentText = (e, editor) => {
+    const form = 'updateForm';
+    const key = 'text';
+    const value = editor.getData();
+
+    handlePostForm(form, key, value);
+  };
+
+  const handleSearchTag = (e, value) => {
+    const newSearchText = value || '';
+    dispatch(changeText({ searchText: newSearchText }));
+  };
+
+  const handleAttachFiles = files => {
+    dispatch(addAttachList({ files }));
+  };
+
+  const onSubmit = e => {
+    e.preventDefault();
+    const {
+      anonymousNickname,
+      anonymousPassword,
+      isNotice,
+      isSecret,
+      text,
+      title,
+      tagList,
+      attachmentList
+    } = updateForm;
+    const anonymous = { anonymousNickname, anonymousPassword };
+    const replaceText = getDecodeHTML(text);
+    const postContent = { title, text: replaceText };
+    const { boardNameEng } = match.params;
+    const attachIdList = attachmentList.map(attach => ({
+      attachId: attach.attachId
+    }));
+
+    dispatch(
+      updatePost({
+        anonymous,
+        attachmentList: attachIdList,
+        boardNameEng,
+        isNotice,
+        isSecret,
+        postContent,
+        tagList
+      })
+    );
+  };
+
+  const onGoBack = () => {
+    const { boardNameEng } = match.params;
+    history.push(`/board/${boardNameEng}`);
+  };
+
+  const onInitialize = () => {
+    dispatch(initializeTag());
+    dispatch(initializePostForm());
+  };
+
+  const onCancel = () => {
+    onInitialize();
+    onGoBack();
+  };
+
+  const onDeleteAttach = attachId => {
+    const form = 'updateForm';
+    const key = 'attachmentList';
+    const value = updateForm.attachmentList.filter(
+      e => e.attachId !== attachId
+    );
+
+    handlePostForm(form, key, value);
+  };
+
+  const handleEditorImg = ({ downloadUrl, fileName }) => {
+    const $p = document.createElement('p');
+    const $img = document.createElement('img');
+    $img.setAttribute('src', downloadUrl);
+    $img.setAttribute('alt', fileName);
+    $p.appendChild($img);
+    return $p.outerHTML;
+  };
+
+  const handleReplyImage = () => {
+    const form = 'updateForm';
+    const attachListData = updateForm.attachmentList.concat(
+      updateAttachData.data
+    );
+    const editorText = `${updateForm.text}${updateAttachData.data
+      .filter(e => confirmFileExtension(e.fileName))
+      .map(e => handleEditorImg(e))
+      .join('')}`;
+
+    handlePostForm(form, 'text', editorText);
+    handlePostForm(form, 'attachmentList', attachListData);
+  };
+
+  const handleRemoveTag = tag => {
+    const form = 'updateForm';
+    const key = 'tagList';
+    const tagListData = updateForm.tagList.filter(e => e.tagId !== tag.tagId);
+    handlePostForm(form, key, tagListData);
+  };
+
+  const handleClearTag = () => {
+    const form = 'updateForm';
+    const key = 'tagList';
+    const tagListData = [];
+    handlePostForm(form, key, tagListData);
+    dispatch(changeText({ searchText: '' }));
+  };
+
+  const handleUpdateTag = () => {
+    if (!searchText) {
+      return setTagUpdateMessage('태그를 입력하세요.');
+    }
+    if (!searchTagData) {
+      return setTagUpdateMessage('검색 결과가 없습니다.');
+    }
+    if (searchTagData && !searchTagData.data.find(e => e.text === searchText)) {
+      return setTagUpdateMessage('존재하지 않는 태그입니다.');
+    }
+    if (updateForm.tagList.find(e => e.text === searchText)) {
+      return setTagUpdateMessage('이미 추가된 태그입니다.');
+    }
+    const form = 'updateForm';
+    const key = 'tagList';
+    const newTag = searchTagData.data.find(e => e.text === searchText);
+    const tagListData = newTag
+      ? updateForm.tagList.concat(newTag)
+      : updateForm.tagList;
+
+    handlePostForm(form, key, tagListData);
+    return setTagUpdateMessage('');
+  };
+
+  useEffect(() => {
+    if (updateAttachData) {
+      handleReplyImage();
+    }
+  }, [updateAttachData]);
+
+  useEffect(() => {
+    if (searchText) {
+      dispatch(searchTag({ text: searchText }));
+    }
+  }, [searchText]);
+
+  useEffect(() => {
+    return onInitialize();
+  }, []);
+
+  const postTitleProps = {
+    value: updateForm.title,
+    onChange: handleChange
+  };
+
+  const postTagAddProps = {
+    value: searchText,
+    tagData: updateForm.tagList,
+    searchTagData,
+    searchTagLoading,
+    searchTagError,
+    tagUpdateMessage,
+    handleUpdateTag,
+    handleSearchTag,
+    handleRemoveTag,
+    handleClearTag
+  };
+
+  const editorProps = {
+    onChange: handleContentText,
+    data: updateForm.text,
+    placeholder: '내용을 입력하세요'
+  };
+
+  const fileAttachDropZoneProps = {
+    loading: attachLoading,
+    error: attachError,
+    handleAttachFiles
+  };
+
+  const attachImageListProps = {
+    attachImgList: updateForm.attachmentList.filter(e =>
+      confirmFileExtension(e.fileName)
+    )
+  };
+
+  const attachListProps = {
+    attachList: updateForm.attachmentList,
+    onDeleteAttach
+  };
+
+  const postUpdateFooterProps = {
+    updateForm,
+    handleChange,
+    handleSecret,
+    handleNotice,
+    onSubmit,
+    onCancel
+  };
+
+  const errorMessageProps = {
+    loading: updateLoading,
+    error: updateError
+  };
+
+  return (
+    <PostUpdate
+      postTitleProps={postTitleProps}
+      postTagAddProps={postTagAddProps}
+      fileAttachDropZoneProps={fileAttachDropZoneProps}
+      attachImageListProps={attachImageListProps}
+      attachListProps={attachListProps}
+      editorProps={editorProps}
+      postUpdateFooterProps={postUpdateFooterProps}
+      errorMessageProps={errorMessageProps}
+    />
+  );
+};
+
+export default withRouter(PostUpdateContainer);

--- a/src/containers/Reply/ReplyUpdateContainer.js
+++ b/src/containers/Reply/ReplyUpdateContainer.js
@@ -167,9 +167,6 @@ const ReplyUpdateContainer = props => {
 
   useEffect(() => {
     handleReply();
-    console.log(match);
-    console.log(location);
-    console.log(history);
   }, [location.search]);
 
   useEffect(() => {

--- a/src/libs/api/menu.js
+++ b/src/libs/api/menu.js
@@ -1,0 +1,11 @@
+import { client, tokenHeader } from './client';
+
+export const loadMenuList = async () => {
+  const token = localStorage.getItem('token');
+  return client.get('/menu', tokenHeader(token)).catch(error => {
+    throw error.response.data;
+  });
+};
+
+// lint 설정 상 한 개 함수만 export 불가능
+export default null;

--- a/src/libs/api/post.js
+++ b/src/libs/api/post.js
@@ -83,6 +83,32 @@ export const addPost = ({
   });
 };
 
+export const updatePost = ({
+  postId,
+  anonymousPassword,
+  attachmentList,
+  boardNameEng,
+  isNotice,
+  isSecret,
+  postContent,
+  tagList
+}) => {
+  const token = localStorage.getItem('token');
+  const body = {
+    postId,
+    anonymousPassword,
+    attachmentList,
+    boardNameEng,
+    isNotice,
+    isSecret,
+    postContent,
+    tagList
+  };
+  return client.put(`/post`, body, tokenHeader(token)).catch(error => {
+    throw error.response.data;
+  });
+};
+
 export const reportPost = async ({ description, reportType, targetId }) => {
   const body = { description, reportType, targetId };
   const token = localStorage.getItem('token');

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -6,6 +6,7 @@ import reply, { replySaga } from './reply';
 import post, { postSaga } from './post';
 import attach, { attachSaga } from './attach';
 import tag, { tagSaga } from './tag';
+import menu, { menuSaga } from './menu';
 
 const rootReducer = combineReducers({
   auth,
@@ -13,7 +14,8 @@ const rootReducer = combineReducers({
   post,
   reply,
   attach,
-  tag
+  tag,
+  menu
 });
 
 export function* rootSaga() {
@@ -23,7 +25,8 @@ export function* rootSaga() {
     postSaga(),
     replySaga(),
     attachSaga(),
-    tagSaga()
+    tagSaga(),
+    menuSaga()
   ]);
 }
 

--- a/src/modules/menu/index.js
+++ b/src/modules/menu/index.js
@@ -1,0 +1,44 @@
+import { createAction, handleActions } from 'redux-actions';
+import { takeLatest } from 'redux-saga/effects';
+import * as api from '../../libs/api/menu';
+import {
+  createRequestActionTypes,
+  createRequestSaga
+} from '../../libs/createRequestSaga';
+import reducerUtils from '../../libs/reducerUtils';
+
+const INITIALIZE = 'menu/INITIALIZE';
+const [LOAD_MENU_LIST, LOAD_MENU_LIST_SUCCESS, LOAD_MENU_LIST_FAILURE] =
+  createRequestActionTypes('menu/LOAD_MENU_LIST');
+
+export const initialize = createAction(INITIALIZE);
+export const loadMenuList = createAction(LOAD_MENU_LIST);
+
+const loadMenuListSage = createRequestSaga(LOAD_MENU_LIST, api.loadMenuList);
+
+export function* menuSaga() {
+  yield takeLatest(LOAD_MENU_LIST, loadMenuListSage);
+}
+
+const initialState = {
+  loadedMenuList: reducerUtils.initial()
+};
+
+export default handleActions(
+  {
+    [INITIALIZE]: () => initialState,
+    [LOAD_MENU_LIST]: state => ({
+      ...state,
+      loadedMenuList: reducerUtils.loading(state.loadedMenuList.data)
+    }),
+    [LOAD_MENU_LIST_SUCCESS]: (state, { payload: response }) => ({
+      ...state,
+      loadedMenuList: reducerUtils.success(response)
+    }),
+    [LOAD_MENU_LIST_FAILURE]: (state, { payload: error }) => ({
+      ...state,
+      loadedMenuList: reducerUtils.error(error)
+    })
+  },
+  initialState
+);

--- a/src/modules/post/index.js
+++ b/src/modules/post/index.js
@@ -347,15 +347,15 @@ export default handleActions(
     }),
     [UPDATE_POST]: state => ({
       ...state,
-      addPost: reducerUtils.loading(state.addPost.data)
+      updatePost: reducerUtils.loading(state.updatePost.data)
     }),
     [UPDATE_POST_SUCCESS]: (state, { payload: response }) => ({
       ...state,
-      addPost: reducerUtils.success(response)
+      updatePost: reducerUtils.success(response)
     }),
     [UPDATE_POST_FAILURE]: (state, { payload: error }) => ({
       ...state,
-      addPost: reducerUtils.error(error)
+      updatePost: reducerUtils.error(error)
     }),
     [POST_REPORT]: state => ({
       ...state,

--- a/src/modules/post/index.js
+++ b/src/modules/post/index.js
@@ -18,9 +18,6 @@ const CHANGE_FIELD = 'post/CHANGE_FIELD';
 const [LOAD_POST_LIST, LOAD_POST_LIST_SUCCESS, LOAD_POST_LIST_FAILURE] =
   createRequestActionTypes('post/LOAD_POST_LIST');
 
-const [LOAD_MENU_LIST, LOAD_MENU_LIST_SUCCESS, LOAD_MENU_LIST_FAILURE] =
-  createRequestActionTypes('post/LOAD_MENU_LIST');
-
 const [SEARCH_POST, SEARCH_POST_SUCCESS, SEARCH_POST_FAILURE] =
   createRequestActionTypes('post/SEARCH_POST');
 
@@ -72,8 +69,6 @@ export const loadPostList = createAction(
     size
   })
 );
-
-export const loadMenuList = createAction(LOAD_MENU_LIST);
 
 export const searchPost = createAction(
   SEARCH_POST,
@@ -161,7 +156,6 @@ export const postReport = createAction(
 
 // Sagas
 const loadPostListSaga = createRequestSaga(LOAD_POST_LIST, api.loadPostList);
-const loadMenuListSage = createRequestSaga(LOAD_MENU_LIST, api.loadMenuList);
 const searchPostSaga = createRequestSaga(SEARCH_POST, api.searchPost);
 const loadPostSaga = createRequestSaga(LOAD_POST, api.loadPost);
 const loadSecretPostSaga = createRequestSaga(
@@ -179,7 +173,6 @@ const postReportSaga = createRequestSaga(POST_REPORT, api.reportPost);
 
 export function* postSaga() {
   yield takeLatest(LOAD_POST_LIST, loadPostListSaga);
-  yield takeLatest(LOAD_MENU_LIST, loadMenuListSage);
   yield takeLatest(SEARCH_POST, searchPostSaga);
   yield takeLatest(LOAD_POST, loadPostSaga);
   yield takeLatest(LOAD_SECRET_POST, loadSecretPostSaga);
@@ -212,7 +205,6 @@ const initialState = {
     tagList: []
   },
   loadedPostList: reducerUtils.initial(),
-  loadedMenuList: reducerUtils.initial(),
   loadedPost: reducerUtils.initial(),
   postDeleteRes: reducerUtils.initial(),
   addPost: reducerUtils.initial(),
@@ -260,18 +252,6 @@ export default handleActions(
     [LOAD_POST_LIST_FAILURE]: (state, { payload: error }) => ({
       ...state,
       loadedPostList: reducerUtils.error(error)
-    }),
-    [LOAD_MENU_LIST]: state => ({
-      ...state,
-      loadedMenuList: reducerUtils.loading(state.loadedMenuList.data)
-    }),
-    [LOAD_MENU_LIST_SUCCESS]: (state, { payload: response }) => ({
-      ...state,
-      loadedMenuList: reducerUtils.success(response)
-    }),
-    [LOAD_MENU_LIST_FAILURE]: (state, { payload: error }) => ({
-      ...state,
-      loadedMenuList: reducerUtils.error(error)
     }),
     [SEARCH_POST]: state => ({
       ...state,

--- a/src/modules/post/index.js
+++ b/src/modules/post/index.js
@@ -42,6 +42,9 @@ const [
 const [ADD_POST, ADD_POST_SUCCESS, ADD_POST_FAILURE] =
   createRequestActionTypes('post/ADD_POST');
 
+const [UPDATE_POST, UPDATE_POST_SUCCESS, UPDATE_POST_FAILURE] =
+  createRequestActionTypes('post/UPDATE_POST');
+
 const [POST_REPORT, POST_REPORT_SUCCESS, POST_REPORT_FAILURE] =
   createRequestActionTypes('post/POST_REPORT');
 
@@ -124,6 +127,29 @@ export const addPost = createAction(
   })
 );
 
+export const updatePost = createAction(
+  UPDATE_POST,
+  ({
+    postId,
+    anonymousPassword,
+    attachmentList,
+    boardNameEng,
+    isNotice,
+    isSecret,
+    postContent,
+    tagList
+  }) => ({
+    postId,
+    anonymousPassword,
+    attachmentList,
+    boardNameEng,
+    isNotice,
+    isSecret,
+    postContent,
+    tagList
+  })
+);
+
 export const postReport = createAction(
   POST_REPORT,
   ({ description, reportType, targetId }) => ({
@@ -148,6 +174,7 @@ const anonymousPostDeleteSaga = createRequestSaga(
   api.anonymousPostDelete
 );
 const addPostSaga = createRequestSaga(ADD_POST, api.addPost);
+const updatePostSaga = createRequestSaga(UPDATE_POST, api.updatePost);
 const postReportSaga = createRequestSaga(POST_REPORT, api.reportPost);
 
 export function* postSaga() {
@@ -159,6 +186,7 @@ export function* postSaga() {
   yield takeLatest(POST_DELETE, postDeleteSaga);
   yield takeLatest(ANONYMOUS_POST_DELETE, anonymousPostDeleteSaga);
   yield takeLatest(ADD_POST, addPostSaga);
+  yield takeLatest(UPDATE_POST, updatePostSaga);
   yield takeLatest(POST_REPORT, postReportSaga);
 }
 
@@ -174,11 +202,21 @@ const initialState = {
     title: '',
     tagList: []
   },
+  updateForm: {
+    anonymousPassword: '',
+    attachmentList: [],
+    isNotice: 'NORMAL',
+    isSecret: 'NORMAL',
+    text: '',
+    title: '',
+    tagList: []
+  },
   loadedPostList: reducerUtils.initial(),
   loadedMenuList: reducerUtils.initial(),
   loadedPost: reducerUtils.initial(),
   postDeleteRes: reducerUtils.initial(),
   addPost: reducerUtils.initial(),
+  updatePost: reducerUtils.initial(),
   reportRes: reducerUtils.initial()
 };
 
@@ -189,6 +227,15 @@ export default handleActions(
       ...state,
       addForm: {
         anonymousNickname: '',
+        anonymousPassword: '',
+        attachmentList: [],
+        isNotice: 'NORMAL',
+        isSecret: 'NORMAL',
+        text: '',
+        title: '',
+        tagList: []
+      },
+      updateForm: {
         anonymousPassword: '',
         attachmentList: [],
         isNotice: 'NORMAL',
@@ -295,6 +342,18 @@ export default handleActions(
       addPost: reducerUtils.success(response)
     }),
     [ADD_POST_FAILURE]: (state, { payload: error }) => ({
+      ...state,
+      addPost: reducerUtils.error(error)
+    }),
+    [UPDATE_POST]: state => ({
+      ...state,
+      addPost: reducerUtils.loading(state.addPost.data)
+    }),
+    [UPDATE_POST_SUCCESS]: (state, { payload: response }) => ({
+      ...state,
+      addPost: reducerUtils.success(response)
+    }),
+    [UPDATE_POST_FAILURE]: (state, { payload: error }) => ({
       ...state,
       addPost: reducerUtils.error(error)
     }),

--- a/src/pages/BoardPage.js
+++ b/src/pages/BoardPage.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import styled from 'styled-components';
+import BoardContainer from '../containers/Board/BoardContainer';
+
+const MainWrapper = styled.div`
+  margin: auto;
+  margin-top: 2rem;
+  width: 70vw;
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 1.5rem;
+  box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
+  @media ${props => props.theme.mobile} {
+    width: calc(100vw - 1rem);
+    margin-top: 1rem;
+    padding: 0.5rem;
+  }
+`;
+
+const BoardPage = () => {
+  return (
+    <MainWrapper>
+      <BoardContainer />
+    </MainWrapper>
+  );
+};
+
+export default BoardPage;

--- a/src/pages/PostPage.js
+++ b/src/pages/PostPage.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from 'styled-components';
+import BoardContainer from '../containers/Board/BoardContainer';
+import PostContainer from '../containers/Post/PostContainer';
+
+const MainWrapper = styled.div`
+  margin: auto;
+  margin-top: 3rem;
+  width: 70vw;
+  max-width: 100%;
+  padding: 1.5rem;
+  display: display;
+  align-items: center;
+  background-color: #ffffff;
+  box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
+  @media ${props => props.theme.mobile} {
+    width: calc(100vw - 1rem);
+    margin-top: 1rem;
+    padding: 0;
+  }
+`;
+const PostPage = () => {
+  return (
+    <>
+      <MainWrapper>
+        <PostContainer />
+      </MainWrapper>
+      <MainWrapper>
+        <BoardContainer />
+      </MainWrapper>
+    </>
+  );
+};
+
+export default PostPage;

--- a/src/pages/PostUpdatePage.js
+++ b/src/pages/PostUpdatePage.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import styled from 'styled-components';
+import PostUpdateContainer from '../containers/Post/PostUpdateContainer';
+
+const ContentWrapper = styled.div`
+  margin-top: 3rem;
+  width: calc(100% - 4rem);
+  padding: 2rem;
+  flex-direction: column;
+  align-items: center;
+  background-color: #ffffff;
+  box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
+  @media ${props => props.theme.mobile} {
+    width: calc(100% - 1rem);
+    padding: 0.5rem;
+  }
+`;
+
+const MainWrapper = styled.div`
+  margin: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 70vw;
+  @media ${props => props.theme.mobile} {
+    width: 100vw;
+  }
+`;
+
+const PostWritePage = () => {
+  return (
+    <MainWrapper>
+      <ContentWrapper>
+        <PostUpdateContainer />
+      </ContentWrapper>
+    </MainWrapper>
+  );
+};
+
+export default PostWritePage;


### PR DESCRIPTION
- 게시글 수정 추가
- 게시글 수정 페이지 입장 시 기존 데이터 출력
- 게시글 추가, 수정 시 화면 전환이 이루어지지 않는 문제 해결
- menu 관련 api 및 redux 설정 post 에서 menu로 뺌 
  (기능도 다르고, post 쪽에서 동작하려니 영역이 겹쳐서 initialize 하면 메뉴가 사라짐)
- React-router-dom Switch 추가 및 PostContainer, BoardContainer 를 각각 PostPage, BoardPage 만들어서 출력
  (url을 통한 입장이 동작안하고, 페이지 전환 시 refresh가 안되서 바꿈)