### PR TITLE
[KIT-239][FE]아이디/비밀번호 찾기 페이지 구현

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -3,6 +3,7 @@ import { Route, Redirect, Switch } from 'react-router-dom';
 import styled from 'styled-components';
 import HeaderContainer from './containers/Header/HeaderContainer';
 import ProfilePage from './pages/ProfilePage';
+import ForgotPage from './pages/ForgotPage';
 import SignupPageContainer from './containers/SignupPage/SignupPageContainer';
 import SignoutContainer from './containers/Signout/SignoutContainer';
 import SigninContainer from './containers/Signin/SigninContainer';
@@ -24,6 +25,7 @@ const Routes = () => (
       <Switch>
         <Route exact path="/profile/:userId" component={ProfilePage} />
         <Route exact path="/signup" component={SignupPageContainer} />
+        <Route exact path="/forgot" component={ForgotPage} />
         <Route exact path="/signout" component={SignoutContainer} />
         <Route exact path="/signin" component={SigninContainer} />
         <Route

--- a/src/Router.js
+++ b/src/Router.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components';
 import { Route, Redirect, Switch } from 'react-router-dom';
 import HeaderContainer from './containers/Header/HeaderContainer';
 import ProfilePage from './pages/ProfilePage';
@@ -13,9 +14,14 @@ import PostPage from './pages/PostPage';
 import BoardPage from './pages/BoardPage';
 import FeedbackContainer from './containers/Feedback/FeedbackContainer';
 
+const BlankBox = styled.div`
+  height: 96px;
+`;
+
 const Routes = () => (
   <>
     <HeaderContainer />
+    <BlankBox />
     <Switch>
       <Route exact path="/profile/:userId" component={ProfilePage} />
       <Route exact path="/signup" component={SignupPageContainer} />

--- a/src/components/Forgot/Forgot.js
+++ b/src/components/Forgot/Forgot.js
@@ -61,7 +61,7 @@ const BoxTitle = styled.h2`
 `;
 
 const FindIdBox = props => {
-  const { onFindIdSubmit, onChange, emailForm, findIdData, findIdLoading } =
+  const { onFindIdSubmit, onChange, myInfoForm, findIdData, findIdLoading } =
     props;
 
   return (
@@ -77,7 +77,7 @@ const FindIdBox = props => {
             label="가입 이메일"
             variant="standard"
             onChange={onChange}
-            value={emailForm.id}
+            value={myInfoForm.email}
             type="email"
           />
           <Button variant="contained" size="small" type="submit">
@@ -95,25 +95,38 @@ const FindIdBox = props => {
 };
 
 const FindPwBox = props => {
-  const { question } = props;
+  const {
+    myInfoForm,
+    onChange,
+    onFindQuestionSubmit,
+    findQuestionData,
+    findQuestionLoading
+  } = props;
   return (
     <FindBox>
+      {findQuestionLoading && <LoadingCircle />}
       <BoxTitle> 비밀번호 찾기</BoxTitle>
-      <FormFlex>
+      <FormFlex onSubmit={onFindQuestionSubmit}>
         <TextFieldButtonBox>
           <FormTextField
             autoFocus
-            id="id"
-            name="id"
+            id="userId"
+            name="userId"
             label="ID"
+            onChange={onChange}
+            value={myInfoForm.userId}
             variant="standard"
             type="id"
           />
-          <Button variant="contained" size="small">
+          <Button variant="contained" size="small" type="submit">
             내 질문 조회
           </Button>
         </TextFieldButtonBox>
-        <QuestionBox>{question}</QuestionBox>
+        {findQuestionData ? (
+          <YourIdBox>{findQuestionData.data.userId} 입니다</YourIdBox>
+        ) : (
+          <QuestionBox>아이디 조회를 하세요</QuestionBox>
+        )}
       </FormFlex>
       <FormFlex>
         <TextFieldButtonBox>
@@ -125,7 +138,7 @@ const FindPwBox = props => {
             type="string"
           />
           <Button variant="contained" size="small">
-            비밀번호 조회
+            비밀번호 전송
           </Button>
         </TextFieldButtonBox>
       </FormFlex>
@@ -135,23 +148,31 @@ const FindPwBox = props => {
 
 const Forgot = props => {
   const {
-    question,
     findIdData,
     findIdLoading,
+    findQuestionData,
+    findQuestionLoading,
     onChange,
-    emailForm,
-    onFindIdSubmit
+    myInfoForm,
+    onFindIdSubmit,
+    onFindQuestionSubmit
   } = props;
   return (
     <MainTable>
       <FindIdBox
         onFindIdSubmit={onFindIdSubmit}
         onChange={onChange}
-        emailForm={emailForm}
+        myInfoForm={myInfoForm}
         findIdData={findIdData}
         findIdLoading={findIdLoading}
       />
-      <FindPwBox question={question} />
+      <FindPwBox
+        myInfoForm={myInfoForm}
+        onChange={onChange}
+        onFindQuestionSubmit={onFindQuestionSubmit}
+        findQuestionData={findQuestionData}
+        findQuestionLoading={findQuestionLoading}
+      />
     </MainTable>
   );
 };

--- a/src/components/Forgot/Forgot.js
+++ b/src/components/Forgot/Forgot.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const MainTable = styled.div`
+  padding: 12px;
+  margin: 8px;
+  box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
+`;
+
+const Forgot = () => {
+  return <MainTable>비밀번호를 찾자~</MainTable>;
+};
+
+export default Forgot;

--- a/src/components/Forgot/Forgot.js
+++ b/src/components/Forgot/Forgot.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
-import { TextField, Button } from '@mui/material';
+import { CircularProgress, TextField, Button } from '@mui/material';
+
+const LoadingCircle = styled(CircularProgress)`
+  position: absolute;
+  bottom: 50vh;
+`;
 
 const MainTable = styled.div`
   padding: 12px;
@@ -41,68 +46,112 @@ const QuestionBox = styled.div`
   text-align: left;
 `;
 
+const YourIdBox = styled.div`
+  padding-top: 12px;
+  margin-top: 12px;
+  font-size: 1.2rem;
+  font-weight: 600;
+  text-align: left;
+`;
+
 const BoxTitle = styled.h2`
   margin-bottom: 12px;
   font-size: 1.2rem;
   font-weight: 600;
 `;
 
+const FindIdBox = props => {
+  const { onFindIdSubmit, onChange, emailForm, findIdData, findIdLoading } =
+    props;
+
+  return (
+    <FindBox>
+      {findIdLoading && <LoadingCircle />}
+      <BoxTitle>ID 찾기</BoxTitle>
+      <FormFlex onSubmit={onFindIdSubmit}>
+        <TextFieldButtonBox>
+          <FormTextField
+            autoFocus
+            id="email"
+            name="email"
+            label="가입 이메일"
+            variant="standard"
+            onChange={onChange}
+            value={emailForm.id}
+            type="email"
+          />
+          <Button variant="contained" size="small" type="submit">
+            아이디 조회
+          </Button>
+        </TextFieldButtonBox>
+        {findIdData ? (
+          <YourIdBox>{findIdData.data.id} 입니다</YourIdBox>
+        ) : (
+          <QuestionBox>아이디 조회를 하세요</QuestionBox>
+        )}
+      </FormFlex>
+    </FindBox>
+  );
+};
+
+const FindPwBox = props => {
+  const { question } = props;
+  return (
+    <FindBox>
+      <BoxTitle> 비밀번호 찾기</BoxTitle>
+      <FormFlex>
+        <TextFieldButtonBox>
+          <FormTextField
+            autoFocus
+            id="id"
+            name="id"
+            label="ID"
+            variant="standard"
+            type="id"
+          />
+          <Button variant="contained" size="small">
+            내 질문 조회
+          </Button>
+        </TextFieldButtonBox>
+        <QuestionBox>{question}</QuestionBox>
+      </FormFlex>
+      <FormFlex>
+        <TextFieldButtonBox>
+          <FormTextField
+            id="answer"
+            name="answer"
+            label="질문에 대한 답변"
+            variant="standard"
+            type="string"
+          />
+          <Button variant="contained" size="small">
+            비밀번호 조회
+          </Button>
+        </TextFieldButtonBox>
+      </FormFlex>
+    </FindBox>
+  );
+};
+
 const Forgot = props => {
-  const { yourId, question } = props;
+  const {
+    question,
+    findIdData,
+    findIdLoading,
+    onChange,
+    emailForm,
+    onFindIdSubmit
+  } = props;
   return (
     <MainTable>
-      <FindBox>
-        <BoxTitle>ID 찾기</BoxTitle>
-        <FormFlex>
-          <TextFieldButtonBox>
-            <FormTextField
-              autoFocus
-              id="email"
-              name="email"
-              label="가입 이메일"
-              variant="standard"
-              type="email"
-            />
-            <Button variant="contained" size="small">
-              아이디 조회
-            </Button>
-          </TextFieldButtonBox>
-          <QuestionBox>{yourId}</QuestionBox>
-        </FormFlex>
-      </FindBox>
-      <FindBox>
-        <BoxTitle> 비밀번호 찾기</BoxTitle>
-        <FormFlex>
-          <TextFieldButtonBox>
-            <FormTextField
-              autoFocus
-              id="id"
-              name="id"
-              label="ID"
-              variant="standard"
-              type="id"
-            />
-            <Button variant="contained" size="small">
-              내 질문 조회
-            </Button>
-          </TextFieldButtonBox>
-          <QuestionBox>{question}</QuestionBox>
-        </FormFlex>
-        <FormFlex>
-          <TextFieldButtonBox>
-            <FormTextField
-              id="answer"
-              name="answer"
-              label="질문에 대한 답변"
-              variant="standard"
-              type="string"
-            />
-            <Button variant="contained" size="small">
-              비밀번호 조회
-            </Button>
-          </TextFieldButtonBox>
-        </FormFlex>
-      </FindBox>
+      <FindIdBox
+        onFindIdSubmit={onFindIdSubmit}
+        onChange={onChange}
+        emailForm={emailForm}
+        findIdData={findIdData}
+        findIdLoading={findIdLoading}
+      />
+      <FindPwBox question={question} />
     </MainTable>
   );
 };

--- a/src/components/Forgot/Forgot.js
+++ b/src/components/Forgot/Forgot.js
@@ -1,14 +1,103 @@
 import React from 'react';
 import styled from 'styled-components';
+import { TextField, Button } from '@mui/material';
 
 const MainTable = styled.div`
   padding: 12px;
   margin: 8px;
   box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
+  display: flex;
+  justify-content: center;
 `;
 
-const Forgot = () => {
-  return <MainTable>비밀번호를 찾자~</MainTable>;
+const FindBox = styled.div`
+  text-align: center;
+  margin: 48px;
+`;
+
+const FormFlex = styled.form`
+  display: flex;
+  flex-direction: column;
+  padding: 12px 24px 0px 24px;
+`;
+
+const FormTextField = styled(TextField)`
+  min-width: 280px;
+  margin: 4px;
+  margin="dense"
+  variant="standard"
+  fullWidth
+  `;
+
+const TextFieldButtonBox = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const QuestionBox = styled.div`
+  padding-top: 12px;
+  margin-top: 12px;
+  font-size: 1rem;
+  text-align: left;
+`;
+
+const BoxTitle = styled.h2`
+  margin-bottom: 12px;
+  font-size: 1.2rem;
+  font-weight: 600;
+`;
+
+const Forgot = props => {
+  const { yourId, question } = props;
+  return (
+    <MainTable>
+      <FindBox>
+        <BoxTitle>ID 찾기</BoxTitle>
+        <FormFlex>
+          <TextFieldButtonBox>
+            <FormTextField
+              autoFocus
+              id="email"
+              name="email"
+              label="가입 이메일"
+              variant="standard"
+              type="email"
+            />
+            <Button variant="contained" size="small">
+              아이디 조회
+            </Button>
+          </TextFieldButtonBox>
+          <QuestionBox>{yourId}</QuestionBox>
+        </FormFlex>
+      </FindBox>
+      <FindBox>
+        <BoxTitle> 비밀번호 찾기</BoxTitle>
+        <FormFlex>
+          <TextFieldButtonBox>
+            <FormTextField
+              autoFocus
+              id="id"
+              name="id"
+              label="ID"
+              variant="standard"
+              type="id"
+            />
+            <Button variant="contained" size="small">
+              내 질문 조회
+            </Button>
+          </TextFieldButtonBox>
+          <QuestionBox>{question}</QuestionBox>
+          <FormTextField
+            id="answer"
+            name="answer"
+            label="질문에 대한 답변"
+            variant="standard"
+            type="string"
+          />
+        </FormFlex>
+      </FindBox>
+    </MainTable>
+  );
 };
 
 export default Forgot;

--- a/src/components/Forgot/Forgot.js
+++ b/src/components/Forgot/Forgot.js
@@ -100,7 +100,8 @@ const FindPwBox = props => {
     onChange,
     onFindQuestionSubmit,
     findQuestionData,
-    findQuestionLoading
+    findQuestionLoading,
+    onFindPwSubmit
   } = props;
   return (
     <FindBox>
@@ -125,21 +126,29 @@ const FindPwBox = props => {
         {findQuestionData ? (
           <YourIdBox>{findQuestionData.data.userId} 입니다</YourIdBox>
         ) : (
-          <QuestionBox>아이디 조회를 하세요</QuestionBox>
+          <QuestionBox>아이디를 입력하여 내 질문을 조회 하세요</QuestionBox>
         )}
       </FormFlex>
-      <FormFlex>
+      <FormFlex onSubmit={onFindPwSubmit}>
         <TextFieldButtonBox>
           <FormTextField
             id="answer"
             name="answer"
             label="질문에 대한 답변"
+            onChange={onChange}
+            value={myInfoForm.answer}
             variant="standard"
             type="string"
           />
-          <Button variant="contained" size="small">
-            비밀번호 전송
-          </Button>
+          {findQuestionData ? (
+            <Button variant="contained" size="small" type="submit">
+              비밀번호 전송
+            </Button>
+          ) : (
+            <Button variant="contained" size="small" disabled>
+              내 질문 조회를 하세요
+            </Button>
+          )}
         </TextFieldButtonBox>
       </FormFlex>
     </FindBox>
@@ -155,7 +164,8 @@ const Forgot = props => {
     onChange,
     myInfoForm,
     onFindIdSubmit,
-    onFindQuestionSubmit
+    onFindQuestionSubmit,
+    onFindPwSubmit
   } = props;
   return (
     <MainTable>
@@ -172,6 +182,7 @@ const Forgot = props => {
         onFindQuestionSubmit={onFindQuestionSubmit}
         findQuestionData={findQuestionData}
         findQuestionLoading={findQuestionLoading}
+        onFindPwSubmit={onFindPwSubmit}
       />
     </MainTable>
   );

--- a/src/components/Forgot/Forgot.js
+++ b/src/components/Forgot/Forgot.js
@@ -97,20 +97,22 @@ const FindIdBox = props => {
 const FindPwBox = props => {
   const {
     myInfoForm,
+    findIdData,
     onChange,
     onFindQuestionSubmit,
     findQuestionData,
     findQuestionLoading,
-    onFindPwSubmit
+    findPasswordLoading,
+    findPasswordSubmit
   } = props;
   return (
     <FindBox>
       {findQuestionLoading && <LoadingCircle />}
+      {findPasswordLoading && <LoadingCircle />}
       <BoxTitle> 비밀번호 찾기</BoxTitle>
       <FormFlex onSubmit={onFindQuestionSubmit}>
         <TextFieldButtonBox>
           <FormTextField
-            autoFocus
             id="userId"
             name="userId"
             label="ID"
@@ -119,17 +121,23 @@ const FindPwBox = props => {
             variant="standard"
             type="id"
           />
-          <Button variant="contained" size="small" type="submit">
-            내 질문 조회
-          </Button>
+          {findIdData ? (
+            <Button variant="contained" size="small" type="submit">
+              내 질문 조회
+            </Button>
+          ) : (
+            <Button variant="contained" size="small" disabled>
+              내 질문 조회
+            </Button>
+          )}
         </TextFieldButtonBox>
         {findQuestionData ? (
-          <YourIdBox>{findQuestionData.data.userId} 입니다</YourIdBox>
+          <YourIdBox>{findQuestionData.data.text}</YourIdBox>
         ) : (
           <QuestionBox>아이디를 입력하여 내 질문을 조회 하세요</QuestionBox>
         )}
       </FormFlex>
-      <FormFlex onSubmit={onFindPwSubmit}>
+      <FormFlex onSubmit={findPasswordSubmit}>
         <TextFieldButtonBox>
           <FormTextField
             id="answer"
@@ -146,7 +154,7 @@ const FindPwBox = props => {
             </Button>
           ) : (
             <Button variant="contained" size="small" disabled>
-              내 질문 조회를 하세요
+              비밀번호 전송
             </Button>
           )}
         </TextFieldButtonBox>
@@ -161,11 +169,12 @@ const Forgot = props => {
     findIdLoading,
     findQuestionData,
     findQuestionLoading,
+    findPasswordLoading,
     onChange,
     myInfoForm,
     onFindIdSubmit,
     onFindQuestionSubmit,
-    onFindPwSubmit
+    findPasswordSubmit
   } = props;
   return (
     <MainTable>
@@ -179,10 +188,12 @@ const Forgot = props => {
       <FindPwBox
         myInfoForm={myInfoForm}
         onChange={onChange}
+        findIdData={findIdData}
         onFindQuestionSubmit={onFindQuestionSubmit}
         findQuestionData={findQuestionData}
         findQuestionLoading={findQuestionLoading}
-        onFindPwSubmit={onFindPwSubmit}
+        findPasswordSubmit={findPasswordSubmit}
+        findPasswordLoading={findPasswordLoading}
       />
     </MainTable>
   );

--- a/src/components/Forgot/Forgot.js
+++ b/src/components/Forgot/Forgot.js
@@ -87,13 +87,20 @@ const Forgot = props => {
             </Button>
           </TextFieldButtonBox>
           <QuestionBox>{question}</QuestionBox>
-          <FormTextField
-            id="answer"
-            name="answer"
-            label="질문에 대한 답변"
-            variant="standard"
-            type="string"
-          />
+        </FormFlex>
+        <FormFlex>
+          <TextFieldButtonBox>
+            <FormTextField
+              id="answer"
+              name="answer"
+              label="질문에 대한 답변"
+              variant="standard"
+              type="string"
+            />
+            <Button variant="contained" size="small">
+              비밀번호 조회
+            </Button>
+          </TextFieldButtonBox>
         </FormFlex>
       </FindBox>
     </MainTable>

--- a/src/components/LoginDialog/LoginDialog.js
+++ b/src/components/LoginDialog/LoginDialog.js
@@ -152,7 +152,7 @@ const LoginDialog = props => {
             <ErrorText>{error}</ErrorText>
             <LinkWrapper>
               <FindButtonWrapper>
-                <FindLink onClick={handleClose} to="find">
+                <FindLink onClick={handleClose} to="/forgot">
                   forgot?
                 </FindLink>
               </FindButtonWrapper>

--- a/src/containers/Feedback/FeedbackContainer.js
+++ b/src/containers/Feedback/FeedbackContainer.js
@@ -45,6 +45,14 @@ const data = {
     deleteError: '게시글 삭제 실패',
     secretSuccess: '비밀 게시글 조회 성공',
     secretError: '비밀 게시글 조회실패공'
+  },
+  find: {
+    idSuccess: '아이디 찾기 성공',
+    idError: '아이디 찾기 실패',
+    questionSuccess: '내 질문 찾기 성공',
+    questionError: '내 질문 찾기 실패',
+    passwordSuccess: '이메일로 전송 되었습니다',
+    passwordError: '비밀번호 찾기 실패'
   }
 };
 
@@ -120,6 +128,22 @@ const FeedbackContainer = props => {
     postDeleteError: post.postDeleteRes.error,
     postDataSuccess: post.loadedPost.data,
     postDataError: post.loadedPost.errora
+  }));
+
+  const {
+    findIdSuccess,
+    findIdError,
+    findQuestionSuccess,
+    findQuestionError,
+    findPasswordSuccess,
+    findPasswordError
+  } = useSelector(({ find }) => ({
+    findIdSuccess: find.findIdRes.data,
+    findIdError: find.findIdRes.error,
+    findQuestionSuccess: find.findQuestionRes.data,
+    findQuestionError: find.findQuestionRes.error,
+    findPasswordSuccess: find.findPasswordRes.data,
+    findPasswordError: find.findPasswordRes.error
   }));
 
   const handleClose = () => {
@@ -203,6 +227,34 @@ const FeedbackContainer = props => {
     replyUpdateError,
     replyDeleteError,
     replySecretCheckError
+  ]);
+
+  useEffect(() => {
+    if (findIdSuccess) handleFeedback('success', data.find.idSuccess);
+    if (findQuestionSuccess)
+      handleFeedback('success', data.find.questionSuccess);
+    if (findPasswordSuccess)
+      handleFeedback('success', data.find.passwordSuccess);
+
+    if (findIdError)
+      handleFeedback('error', findIdError.message || data.find.idError);
+    if (findQuestionError)
+      handleFeedback(
+        'error',
+        findQuestionError.message || data.find.questionError
+      );
+    if (findPasswordError)
+      handleFeedback(
+        'error',
+        findPasswordError.message || data.find.passwordError
+      );
+  }, [
+    findIdSuccess,
+    findQuestionSuccess,
+    findPasswordSuccess,
+    findIdError,
+    findQuestionError,
+    findPasswordError
   ]);
 
   useEffect(() => {

--- a/src/containers/Forgot/ForgotContainer.js
+++ b/src/containers/Forgot/ForgotContainer.js
@@ -1,42 +1,62 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Forgot from '../../components/Forgot/Forgot';
-import { findId, findQuestion } from '../../modules/account';
+import { findId, findQuestion, changeField } from '../../modules/find';
 
 const ForgotContainer = () => {
   const dispatch = useDispatch();
 
   const {
+    emailForm,
     findIdData,
     findIdLoading,
     findIdError,
     findQuestionData,
     findQuestionLoading,
     findQuestionError
-  } = useSelector(({ account }) => ({
-    findIdData: account.findIdRes.data,
-    findIdLoading: account.findIdRes.loading,
-    findIdError: account.findIdRes.error,
-    findQuestionData: account.findQuestionRes.data,
-    findQuestionLoading: account.findQuestionRes.loading,
-    findQuestionError: account.findQuestionRes.error
+  } = useSelector(({ find }) => ({
+    emailForm: find.myEmail,
+    findIdData: find.findIdRes.data,
+    findIdLoading: find.findIdRes.loading,
+    findIdError: find.findIdRes.error,
+    findQuestionData: find.findQuestionRes.data,
+    findQuestionLoading: find.findQuestionRes.loading,
+    findQuestionError: find.findQuestionRes.error
   }));
-  const email = 'alsanrlf@naver.com';
-  const userId = 'alsanrlf';
   useEffect(() => {
-    dispatch(findId({ email }));
+    const userId = 'alsanrlf';
     dispatch(findQuestion({ userId }));
   }, []);
-  console.log(findIdData, findIdError);
-  console.log(findQuestionData, findQuestionError, findQuestionLoading);
+
+  const onChange = e => {
+    const { value, name } = e.target;
+    dispatch(
+      changeField({
+        form: 'myEmail',
+        key: name,
+        value
+      })
+    );
+  };
+
+  const onFindIdSubmit = e => {
+    e.preventDefault();
+    const { email } = emailForm;
+    dispatch(findId({ email }));
+  };
 
   return (
     <Forgot
-      yourId="가입 이메일을 조회해 주세요"
       question="내 질문 조회를 하세요"
       findIdData={findIdData}
       findIdLoading={findIdLoading}
       findIdError={findIdError}
+      findQuestionData={findQuestionData}
+      findQuestionError={findQuestionError}
+      findQuestionLoading={findQuestionLoading}
+      onChange={onChange}
+      emailForm={emailForm}
+      onFindIdSubmit={onFindIdSubmit}
     />
   );
 };

--- a/src/containers/Forgot/ForgotContainer.js
+++ b/src/containers/Forgot/ForgotContainer.js
@@ -2,7 +2,12 @@ import React from 'react';
 import Forgot from '../../components/Forgot/Forgot';
 
 const ForgotContainer = () => {
-  return <Forgot />;
+  return (
+    <Forgot
+      yourId="가입 이메일을 확인하세요"
+      question="내 질문 조회를 하세요"
+    />
+  );
 };
 
 export default ForgotContainer;

--- a/src/containers/Forgot/ForgotContainer.js
+++ b/src/containers/Forgot/ForgotContainer.js
@@ -1,28 +1,42 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Forgot from '../../components/Forgot/Forgot';
-import { findId } from '../../modules/account';
+import { findId, findQuestion } from '../../modules/account';
 
 const ForgotContainer = () => {
   const dispatch = useDispatch();
 
-  const { data, loading, error } = useSelector(({ account }) => ({
-    data: account.findIdRes.data,
-    loading: account.findIdRes.loading,
-    error: account.findIdRes.error
+  const {
+    findIdData,
+    findIdLoading,
+    findIdError,
+    findQuestionData,
+    findQuestionLoading,
+    findQuestionError
+  } = useSelector(({ account }) => ({
+    findIdData: account.findIdRes.data,
+    findIdLoading: account.findIdRes.loading,
+    findIdError: account.findIdRes.error,
+    findQuestionData: account.findQuestionRes.data,
+    findQuestionLoading: account.findQuestionRes.loading,
+    findQuestionError: account.findQuestionRes.error
   }));
-  const email = 'alsanrlf@naver.cm';
+  const email = 'alsanrlf@naver.com';
+  const userId = 'alsanrlf';
   useEffect(() => {
     dispatch(findId({ email }));
+    dispatch(findQuestion({ userId }));
   }, []);
-  console.log(data, error);
+  console.log(findIdData, findIdError);
+  console.log(findQuestionData, findQuestionError, findQuestionLoading);
+
   return (
     <Forgot
       yourId="가입 이메일을 조회해 주세요"
       question="내 질문 조회를 하세요"
-      data={data}
-      loading={loading}
-      error={error}
+      findIdData={findIdData}
+      findIdLoading={findIdLoading}
+      findIdError={findIdError}
     />
   );
 };

--- a/src/containers/Forgot/ForgotContainer.js
+++ b/src/containers/Forgot/ForgotContainer.js
@@ -1,11 +1,28 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import Forgot from '../../components/Forgot/Forgot';
+import { findId } from '../../modules/account';
 
 const ForgotContainer = () => {
+  const dispatch = useDispatch();
+
+  const { data, loading, error } = useSelector(({ account }) => ({
+    data: account.findIdRes.data,
+    loading: account.findIdRes.loading,
+    error: account.findIdRes.error
+  }));
+  const email = 'alsanrlf@naver.cm';
+  useEffect(() => {
+    dispatch(findId({ email }));
+  }, []);
+  console.log(data, error);
   return (
     <Forgot
-      yourId="가입 이메일을 확인하세요"
+      yourId="가입 이메일을 조회해 주세요"
       question="내 질문 조회를 하세요"
+      data={data}
+      loading={loading}
+      error={error}
     />
   );
 };

--- a/src/containers/Forgot/ForgotContainer.js
+++ b/src/containers/Forgot/ForgotContainer.js
@@ -7,7 +7,7 @@ const ForgotContainer = () => {
   const dispatch = useDispatch();
 
   const {
-    emailForm,
+    myInfoForm,
     findIdData,
     findIdLoading,
     findIdError,
@@ -15,7 +15,7 @@ const ForgotContainer = () => {
     findQuestionLoading,
     findQuestionError
   } = useSelector(({ find }) => ({
-    emailForm: find.myEmail,
+    myInfoForm: find.myInfo,
     findIdData: find.findIdRes.data,
     findIdLoading: find.findIdRes.loading,
     findIdError: find.findIdRes.error,
@@ -32,7 +32,7 @@ const ForgotContainer = () => {
     const { value, name } = e.target;
     dispatch(
       changeField({
-        form: 'myEmail',
+        form: 'myInfo',
         key: name,
         value
       })
@@ -41,13 +41,18 @@ const ForgotContainer = () => {
 
   const onFindIdSubmit = e => {
     e.preventDefault();
-    const { email } = emailForm;
+    const { email } = myInfoForm;
     dispatch(findId({ email }));
+  };
+
+  const onFindQuestionSubmit = e => {
+    e.preventDefault();
+    const { userId } = myInfoForm;
+    dispatch(findQuestion({ userId }));
   };
 
   return (
     <Forgot
-      question="내 질문 조회를 하세요"
       findIdData={findIdData}
       findIdLoading={findIdLoading}
       findIdError={findIdError}
@@ -55,8 +60,9 @@ const ForgotContainer = () => {
       findQuestionError={findQuestionError}
       findQuestionLoading={findQuestionLoading}
       onChange={onChange}
-      emailForm={emailForm}
+      myInfoForm={myInfoForm}
       onFindIdSubmit={onFindIdSubmit}
+      onFindQuestionSubmit={onFindQuestionSubmit}
     />
   );
 };

--- a/src/containers/Forgot/ForgotContainer.js
+++ b/src/containers/Forgot/ForgotContainer.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import Forgot from '../../components/Forgot/Forgot';
+
+const ForgotContainer = () => {
+  return <Forgot />;
+};
+
+export default ForgotContainer;

--- a/src/containers/Forgot/ForgotContainer.js
+++ b/src/containers/Forgot/ForgotContainer.js
@@ -51,6 +51,14 @@ const ForgotContainer = () => {
     dispatch(findQuestion({ userId }));
   };
 
+  const onFindPwSubmit = e => {
+    e.preventDefault();
+    const { answer, email } = myInfoForm;
+    const { questionId } = findQuestionData.data;
+    const id = myInfoForm.userId;
+    dispatch(findQuestion({ answer, email, id, questionId }));
+  };
+
   return (
     <Forgot
       findIdData={findIdData}
@@ -63,6 +71,7 @@ const ForgotContainer = () => {
       myInfoForm={myInfoForm}
       onFindIdSubmit={onFindIdSubmit}
       onFindQuestionSubmit={onFindQuestionSubmit}
+      onFindPwSubmit={onFindPwSubmit}
     />
   );
 };

--- a/src/containers/Forgot/ForgotContainer.js
+++ b/src/containers/Forgot/ForgotContainer.js
@@ -1,7 +1,12 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Forgot from '../../components/Forgot/Forgot';
-import { findId, findQuestion, changeField } from '../../modules/find';
+import {
+  findId,
+  findQuestion,
+  findPassword,
+  changeField
+} from '../../modules/find';
 
 const ForgotContainer = () => {
   const dispatch = useDispatch();
@@ -13,7 +18,10 @@ const ForgotContainer = () => {
     findIdError,
     findQuestionData,
     findQuestionLoading,
-    findQuestionError
+    findQuestionError,
+    findPasswordData,
+    findPasswordLoading,
+    findPasswordError
   } = useSelector(({ find }) => ({
     myInfoForm: find.myInfo,
     findIdData: find.findIdRes.data,
@@ -21,12 +29,11 @@ const ForgotContainer = () => {
     findIdError: find.findIdRes.error,
     findQuestionData: find.findQuestionRes.data,
     findQuestionLoading: find.findQuestionRes.loading,
-    findQuestionError: find.findQuestionRes.error
+    findQuestionError: find.findQuestionRes.error,
+    findPasswordData: find.findPasswordRes.data,
+    findPasswordLoading: find.findPasswordRes.loading,
+    findPasswordError: find.findPasswordRes.error
   }));
-  useEffect(() => {
-    const userId = 'alsanrlf';
-    dispatch(findQuestion({ userId }));
-  }, []);
 
   const onChange = e => {
     const { value, name } = e.target;
@@ -51,12 +58,12 @@ const ForgotContainer = () => {
     dispatch(findQuestion({ userId }));
   };
 
-  const onFindPwSubmit = e => {
+  const findPasswordSubmit = e => {
     e.preventDefault();
     const { answer, email } = myInfoForm;
     const { questionId } = findQuestionData.data;
     const id = myInfoForm.userId;
-    dispatch(findQuestion({ answer, email, id, questionId }));
+    dispatch(findPassword({ answer, email, id, questionId }));
   };
 
   return (
@@ -67,11 +74,14 @@ const ForgotContainer = () => {
       findQuestionData={findQuestionData}
       findQuestionError={findQuestionError}
       findQuestionLoading={findQuestionLoading}
+      findPasswordData={findPasswordData}
+      findPasswordLoading={findPasswordLoading}
+      findPasswordError={findPasswordError}
       onChange={onChange}
       myInfoForm={myInfoForm}
       onFindIdSubmit={onFindIdSubmit}
       onFindQuestionSubmit={onFindQuestionSubmit}
-      onFindPwSubmit={onFindPwSubmit}
+      findPasswordSubmit={findPasswordSubmit}
     />
   );
 };

--- a/src/libs/api/account.js
+++ b/src/libs/api/account.js
@@ -22,27 +22,3 @@ export const accountDelete = ({ userId }) => {
     throw error.response.data;
   });
 };
-
-export const findId = ({ email }) => {
-  return client.get(`/account/email/${email}`).catch(error => {
-    throw error.response.data;
-  });
-};
-
-export const findQuestion = ({ userId }) => {
-  const token = localStorage.getItem('token');
-  console.log(userId);
-  return client.get(`/account/my/question`, tokenHeader(token)).catch(error => {
-    throw error.response.data;
-  });
-};
-
-export const findPassword = ({ answer, email, id, questionId }) => {
-  const token = localStorage.getItem('token');
-  const parameter = { answer, email, id, questionId };
-  return client
-    .get(`/account/my/question`, parameter, tokenHeader(token))
-    .catch(error => {
-      throw error.response.data;
-    });
-};

--- a/src/libs/api/account.js
+++ b/src/libs/api/account.js
@@ -22,3 +22,9 @@ export const accountDelete = ({ userId }) => {
     throw error.response.data;
   });
 };
+
+export const findId = ({ email }) => {
+  return client.get(`/account/email/${email}`).catch(error => {
+    throw error.response.data;
+  });
+};

--- a/src/libs/api/account.js
+++ b/src/libs/api/account.js
@@ -28,3 +28,11 @@ export const findId = ({ email }) => {
     throw error.response.data;
   });
 };
+
+export const findQuestion = ({ userId }) => {
+  const token = localStorage.getItem('token');
+  console.log(userId);
+  return client.get(`/account/my/question`, tokenHeader(token)).catch(error => {
+    throw error.response.data;
+  });
+};

--- a/src/libs/api/account.js
+++ b/src/libs/api/account.js
@@ -36,3 +36,13 @@ export const findQuestion = ({ userId }) => {
     throw error.response.data;
   });
 };
+
+export const findPassword = ({ answer, email, id, questionId }) => {
+  const token = localStorage.getItem('token');
+  const parameter = { answer, email, id, questionId };
+  return client
+    .get(`/account/my/question`, parameter, tokenHeader(token))
+    .catch(error => {
+      throw error.response.data;
+    });
+};

--- a/src/libs/api/find.js
+++ b/src/libs/api/find.js
@@ -1,4 +1,4 @@
-import { client, tokenHeader } from './client';
+import { client } from './client';
 
 const URL = 'account';
 
@@ -15,11 +15,8 @@ export const findQuestion = ({ userId }) => {
 };
 
 export const findPassword = ({ answer, email, id, questionId }) => {
-  const token = localStorage.getItem('token');
   const parameter = { answer, email, id, questionId };
-  return client
-    .get(`/${URL}/my/question`, parameter, tokenHeader(token))
-    .catch(error => {
-      throw error.response.data;
-    });
+  return client.post(`/${URL}/my/question`, parameter).catch(error => {
+    throw error.response.data;
+  });
 };

--- a/src/libs/api/find.js
+++ b/src/libs/api/find.js
@@ -9,12 +9,9 @@ export const findId = ({ email }) => {
 };
 
 export const findQuestion = ({ userId }) => {
-  const token = localStorage.getItem('token');
-  return client
-    .get(`/${URL}/my/question`, userId, tokenHeader(token))
-    .catch(error => {
-      throw error.response.data;
-    });
+  return client.get(`/${URL}/my/question`, userId).catch(error => {
+    throw error.response.data;
+  });
 };
 
 export const findPassword = ({ answer, email, id, questionId }) => {

--- a/src/libs/api/find.js
+++ b/src/libs/api/find.js
@@ -1,0 +1,28 @@
+import { client, tokenHeader } from './client';
+
+const URL = 'account';
+
+export const findId = ({ email }) => {
+  return client.get(`/account/email/${email}`).catch(error => {
+    throw error.response.data;
+  });
+};
+
+export const findQuestion = ({ userId }) => {
+  const token = localStorage.getItem('token');
+  return client
+    .get(`/${URL}/my/question`, userId, tokenHeader(token))
+    .catch(error => {
+      throw error.response.data;
+    });
+};
+
+export const findPassword = ({ answer, email, id, questionId }) => {
+  const token = localStorage.getItem('token');
+  const parameter = { answer, email, id, questionId };
+  return client
+    .get(`/${URL}/my/question`, parameter, tokenHeader(token))
+    .catch(error => {
+      throw error.response.data;
+    });
+};

--- a/src/libs/api/find.js
+++ b/src/libs/api/find.js
@@ -9,14 +9,14 @@ export const findId = ({ email }) => {
 };
 
 export const findQuestion = ({ userId }) => {
-  return client.get(`/${URL}/my/question`, userId).catch(error => {
+  return client.get(`/${URL}/question/${userId}`).catch(error => {
     throw error.response.data;
   });
 };
 
 export const findPassword = ({ answer, email, id, questionId }) => {
   const parameter = { answer, email, id, questionId };
-  return client.post(`/${URL}/my/question`, parameter).catch(error => {
+  return client.post(`/${URL}/password`, parameter).catch(error => {
     throw error.response.data;
   });
 };

--- a/src/modules/account/index.js
+++ b/src/modules/account/index.js
@@ -17,13 +17,6 @@ const [MY_INFO_EDIT, MY_INFO_EDIT_SUCCESS, MY_INFO_EDIT_FAILURE] =
   createRequestActionTypes('account/MY_INFO_EDIT');
 const [ACCOUNT_DELETE, ACCOUNT_DELETE_SUCCESS, ACCOUNT_DELETE_FAILURE] =
   createRequestActionTypes('account/ACCOUNT_DELETE');
-const [FIND_ID, FIND_ID_SUCCESS, FIND_ID_FAILURE] =
-  createRequestActionTypes('account/FIND_ID');
-const [FIND_QUESTION, FIND_QUESTION_SUCCESS, FIND_QUESTION_FAILURE] =
-  createRequestActionTypes('account/FIND_QUESTION');
-const [FIND_PASSWORD, FIND_PASSWORD_SUCCESS, FIND_PASSWORD_FAILURE] =
-  createRequestActionTypes('account/FIND_PASSWORD');
-
 // Action Creators
 export const initializeForm = createAction(INITIALIZE_FORM, form => form);
 export const changeField = createAction(
@@ -52,39 +45,15 @@ export const accountDelete = createAction(
   })
 );
 
-export const findId = createAction(FIND_ID, ({ email }) => ({
-  email
-}));
-
-export const findQuestion = createAction(FIND_QUESTION, ({ userId }) => ({
-  userId
-}));
-
-export const findPassword = createAction(
-  FIND_PASSWORD,
-  ({ answer, email, id, questionId }) => ({
-    answer,
-    email,
-    id,
-    questionId
-  })
-);
-
 // Sagas
 const myInfoSaga = createRequestSaga(MY_INFO, api.myInfo);
 const myInfoEditSaga = createRequestSaga(MY_INFO_EDIT, api.myInfoEdit);
 const accountDeleteSaga = createRequestSaga(ACCOUNT_DELETE, api.accountDelete);
-const findIdSaga = createRequestSaga(FIND_ID, api.findId);
-const findQuestionSaga = createRequestSaga(FIND_ID, api.findQuestion);
-const findPasswordSaga = createRequestSaga(FIND_PASSWORD, api.findPassword);
 
 export function* accountSaga() {
   yield takeLatest(MY_INFO, myInfoSaga);
   yield takeLatest(MY_INFO_EDIT, myInfoEditSaga);
   yield takeLatest(ACCOUNT_DELETE, accountDeleteSaga);
-  yield takeLatest(FIND_ID, findIdSaga);
-  yield takeLatest(FIND_QUESTION, findQuestionSaga);
-  yield takeLatest(FIND_PASSWORD, findPasswordSaga);
 }
 
 // reducer
@@ -100,10 +69,7 @@ const initialState = {
   },
   myInfo: reducerUtils.initial(),
   myInfoEditRes: reducerUtils.initial(),
-  accountDeleteRes: reducerUtils.initial(),
-  findIdRes: reducerUtils.initial(),
-  findQuestionRes: reducerUtils.initial(),
-  findPasswordRes: reducerUtils.initial()
+  accountDeleteRes: reducerUtils.initial()
 };
 
 export default handleActions(
@@ -151,42 +117,6 @@ export default handleActions(
     [ACCOUNT_DELETE_FAILURE]: (state, { payload: error }) => ({
       ...state,
       accountDeleteRes: reducerUtils.error(error)
-    }),
-    [FIND_ID]: state => ({
-      ...state,
-      findIdRes: reducerUtils.loading(state.findIdRes.data)
-    }),
-    [FIND_ID_SUCCESS]: (state, { payload: response }) => ({
-      ...state,
-      findIdRes: reducerUtils.success(response)
-    }),
-    [FIND_ID_FAILURE]: (state, { payload: error }) => ({
-      ...state,
-      findIdRes: reducerUtils.error(error)
-    }),
-    [FIND_QUESTION]: state => ({
-      ...state,
-      findQuestionRes: reducerUtils.loading(state.findQuestionRes.data)
-    }),
-    [FIND_QUESTION_SUCCESS]: (state, { payload: response }) => ({
-      ...state,
-      findQuestionRes: reducerUtils.success(response)
-    }),
-    [FIND_QUESTION_FAILURE]: (state, { payload: error }) => ({
-      ...state,
-      findQuestionRes: reducerUtils.error(error)
-    }),
-    [FIND_PASSWORD]: state => ({
-      ...state,
-      findPasswordRes: reducerUtils.loading(state.findPasswordRes.data)
-    }),
-    [FIND_PASSWORD_SUCCESS]: (state, { payload: response }) => ({
-      ...state,
-      findPasswordRes: reducerUtils.success(response)
-    }),
-    [FIND_PASSWORD_FAILURE]: (state, { payload: error }) => ({
-      ...state,
-      findPasswordRes: reducerUtils.error(error)
     })
   },
   initialState

--- a/src/modules/account/index.js
+++ b/src/modules/account/index.js
@@ -21,6 +21,8 @@ const [FIND_ID, FIND_ID_SUCCESS, FIND_ID_FAILURE] =
   createRequestActionTypes('account/FIND_ID');
 const [FIND_QUESTION, FIND_QUESTION_SUCCESS, FIND_QUESTION_FAILURE] =
   createRequestActionTypes('account/FIND_QUESTION');
+const [FIND_PASSWORD, FIND_PASSWORD_SUCCESS, FIND_PASSWORD_FAILURE] =
+  createRequestActionTypes('account/FIND_PASSWORD');
 
 // Action Creators
 export const initializeForm = createAction(INITIALIZE_FORM, form => form);
@@ -58,12 +60,23 @@ export const findQuestion = createAction(FIND_QUESTION, ({ userId }) => ({
   userId
 }));
 
+export const findPassword = createAction(
+  FIND_PASSWORD,
+  ({ answer, email, id, questionId }) => ({
+    answer,
+    email,
+    id,
+    questionId
+  })
+);
+
 // Sagas
 const myInfoSaga = createRequestSaga(MY_INFO, api.myInfo);
 const myInfoEditSaga = createRequestSaga(MY_INFO_EDIT, api.myInfoEdit);
 const accountDeleteSaga = createRequestSaga(ACCOUNT_DELETE, api.accountDelete);
 const findIdSaga = createRequestSaga(FIND_ID, api.findId);
 const findQuestionSaga = createRequestSaga(FIND_ID, api.findQuestion);
+const findPasswordSaga = createRequestSaga(FIND_PASSWORD, api.findPassword);
 
 export function* accountSaga() {
   yield takeLatest(MY_INFO, myInfoSaga);
@@ -71,6 +84,7 @@ export function* accountSaga() {
   yield takeLatest(ACCOUNT_DELETE, accountDeleteSaga);
   yield takeLatest(FIND_ID, findIdSaga);
   yield takeLatest(FIND_QUESTION, findQuestionSaga);
+  yield takeLatest(FIND_PASSWORD, findPasswordSaga);
 }
 
 // reducer
@@ -88,7 +102,8 @@ const initialState = {
   myInfoEditRes: reducerUtils.initial(),
   accountDeleteRes: reducerUtils.initial(),
   findIdRes: reducerUtils.initial(),
-  findQuestionRes: reducerUtils.initial()
+  findQuestionRes: reducerUtils.initial(),
+  findPasswordRes: reducerUtils.initial()
 };
 
 export default handleActions(
@@ -160,6 +175,18 @@ export default handleActions(
     [FIND_QUESTION_FAILURE]: (state, { payload: error }) => ({
       ...state,
       findQuestionRes: reducerUtils.error(error)
+    }),
+    [FIND_PASSWORD]: state => ({
+      ...state,
+      findPasswordRes: reducerUtils.loading(state.findPasswordRes.data)
+    }),
+    [FIND_PASSWORD_SUCCESS]: (state, { payload: response }) => ({
+      ...state,
+      findPasswordRes: reducerUtils.success(response)
+    }),
+    [FIND_PASSWORD_FAILURE]: (state, { payload: error }) => ({
+      ...state,
+      findPasswordRes: reducerUtils.error(error)
     })
   },
   initialState

--- a/src/modules/account/index.js
+++ b/src/modules/account/index.js
@@ -17,6 +17,8 @@ const [MY_INFO_EDIT, MY_INFO_EDIT_SUCCESS, MY_INFO_EDIT_FAILURE] =
   createRequestActionTypes('account/MY_INFO_EDIT');
 const [ACCOUNT_DELETE, ACCOUNT_DELETE_SUCCESS, ACCOUNT_DELETE_FAILURE] =
   createRequestActionTypes('account/ACCOUNT_DELETE');
+const [FIND_ID, FIND_ID_SUCCESS, FIND_ID_FAILURE] =
+  createRequestActionTypes('account/FIND_ID');
 
 // Action Creators
 export const initializeForm = createAction(INITIALIZE_FORM, form => form);
@@ -46,15 +48,21 @@ export const accountDelete = createAction(
   })
 );
 
+export const findId = createAction(FIND_ID, ({ email }) => ({
+  email
+}));
+
 // Sagas
 const myInfoSaga = createRequestSaga(MY_INFO, api.myInfo);
 const myInfoEditSaga = createRequestSaga(MY_INFO_EDIT, api.myInfoEdit);
 const accountDeleteSaga = createRequestSaga(ACCOUNT_DELETE, api.accountDelete);
+const findIdSaga = createRequestSaga(FIND_ID, api.findId);
 
 export function* accountSaga() {
   yield takeLatest(MY_INFO, myInfoSaga);
   yield takeLatest(MY_INFO_EDIT, myInfoEditSaga);
   yield takeLatest(ACCOUNT_DELETE, accountDeleteSaga);
+  yield takeLatest(FIND_ID, findIdSaga);
 }
 
 // reducer
@@ -70,7 +78,8 @@ const initialState = {
   },
   myInfo: reducerUtils.initial(),
   myInfoEditRes: reducerUtils.initial(),
-  accountDeleteRes: reducerUtils.initial()
+  accountDeleteRes: reducerUtils.initial(),
+  findIdRes: reducerUtils.initial()
 };
 
 export default handleActions(
@@ -118,6 +127,18 @@ export default handleActions(
     [ACCOUNT_DELETE_FAILURE]: (state, { payload: error }) => ({
       ...state,
       accountDeleteRes: reducerUtils.error(error)
+    }),
+    [FIND_ID]: state => ({
+      ...state,
+      findIdRes: reducerUtils.loading(state.findIdRes.data)
+    }),
+    [FIND_ID_SUCCESS]: (state, { payload: response }) => ({
+      ...state,
+      findIdRes: reducerUtils.success(response)
+    }),
+    [FIND_ID_FAILURE]: (state, { payload: error }) => ({
+      ...state,
+      findIdRes: reducerUtils.error(error)
     })
   },
   initialState

--- a/src/modules/account/index.js
+++ b/src/modules/account/index.js
@@ -19,6 +19,8 @@ const [ACCOUNT_DELETE, ACCOUNT_DELETE_SUCCESS, ACCOUNT_DELETE_FAILURE] =
   createRequestActionTypes('account/ACCOUNT_DELETE');
 const [FIND_ID, FIND_ID_SUCCESS, FIND_ID_FAILURE] =
   createRequestActionTypes('account/FIND_ID');
+const [FIND_QUESTION, FIND_QUESTION_SUCCESS, FIND_QUESTION_FAILURE] =
+  createRequestActionTypes('account/FIND_QUESTION');
 
 // Action Creators
 export const initializeForm = createAction(INITIALIZE_FORM, form => form);
@@ -52,17 +54,23 @@ export const findId = createAction(FIND_ID, ({ email }) => ({
   email
 }));
 
+export const findQuestion = createAction(FIND_QUESTION, ({ userId }) => ({
+  userId
+}));
+
 // Sagas
 const myInfoSaga = createRequestSaga(MY_INFO, api.myInfo);
 const myInfoEditSaga = createRequestSaga(MY_INFO_EDIT, api.myInfoEdit);
 const accountDeleteSaga = createRequestSaga(ACCOUNT_DELETE, api.accountDelete);
 const findIdSaga = createRequestSaga(FIND_ID, api.findId);
+const findQuestionSaga = createRequestSaga(FIND_ID, api.findQuestion);
 
 export function* accountSaga() {
   yield takeLatest(MY_INFO, myInfoSaga);
   yield takeLatest(MY_INFO_EDIT, myInfoEditSaga);
   yield takeLatest(ACCOUNT_DELETE, accountDeleteSaga);
   yield takeLatest(FIND_ID, findIdSaga);
+  yield takeLatest(FIND_QUESTION, findQuestionSaga);
 }
 
 // reducer
@@ -79,7 +87,8 @@ const initialState = {
   myInfo: reducerUtils.initial(),
   myInfoEditRes: reducerUtils.initial(),
   accountDeleteRes: reducerUtils.initial(),
-  findIdRes: reducerUtils.initial()
+  findIdRes: reducerUtils.initial(),
+  findQuestionRes: reducerUtils.initial()
 };
 
 export default handleActions(
@@ -139,6 +148,18 @@ export default handleActions(
     [FIND_ID_FAILURE]: (state, { payload: error }) => ({
       ...state,
       findIdRes: reducerUtils.error(error)
+    }),
+    [FIND_QUESTION]: state => ({
+      ...state,
+      findQuestionRes: reducerUtils.loading(state.findQuestionRes.data)
+    }),
+    [FIND_QUESTION_SUCCESS]: (state, { payload: response }) => ({
+      ...state,
+      findQuestionRes: reducerUtils.success(response)
+    }),
+    [FIND_QUESTION_FAILURE]: (state, { payload: error }) => ({
+      ...state,
+      findQuestionRes: reducerUtils.error(error)
     })
   },
   initialState

--- a/src/modules/find/index.js
+++ b/src/modules/find/index.js
@@ -1,0 +1,119 @@
+import { createAction, handleActions } from 'redux-actions';
+import { takeLatest } from 'redux-saga/effects';
+import produce from 'immer';
+import * as api from '../../libs/api/find';
+import {
+  createRequestActionTypes,
+  createRequestSaga
+} from '../../libs/createRequestSaga';
+import reducerUtils from '../../libs/reducerUtils';
+
+// Actions
+const INITIALIZE_FORM = 'find/INITIALIZE_FORM';
+const CHANGE_FIELD = 'find/CHANGE_FIELD';
+const [FIND_ID, FIND_ID_SUCCESS, FIND_ID_FAILURE] =
+  createRequestActionTypes('find/FIND_ID');
+const [FIND_QUESTION, FIND_QUESTION_SUCCESS, FIND_QUESTION_FAILURE] =
+  createRequestActionTypes('find/FIND_QUESTION');
+const [FIND_PASSWORD, FIND_PASSWORD_SUCCESS, FIND_PASSWORD_FAILURE] =
+  createRequestActionTypes('find/FIND_PASSWORD');
+
+// Action Creators
+export const initializeForm = createAction(INITIALIZE_FORM, form => form);
+export const changeField = createAction(
+  CHANGE_FIELD,
+  ({ form, key, value }) => ({
+    form,
+    key,
+    value
+  })
+);
+
+export const findId = createAction(FIND_ID, ({ email }) => ({
+  email
+}));
+
+export const findQuestion = createAction(FIND_QUESTION, ({ userId }) => ({
+  userId
+}));
+
+export const findPassword = createAction(
+  FIND_PASSWORD,
+  ({ answer, email, id, questionId }) => ({
+    answer,
+    email,
+    id,
+    questionId
+  })
+);
+
+// Sagas
+const findIdSaga = createRequestSaga(FIND_ID, api.findId);
+const findQuestionSaga = createRequestSaga(FIND_ID, api.findQuestion);
+const findPasswordSaga = createRequestSaga(FIND_PASSWORD, api.findPassword);
+
+export function* findSaga() {
+  yield takeLatest(FIND_ID, findIdSaga);
+  yield takeLatest(FIND_QUESTION, findQuestionSaga);
+  yield takeLatest(FIND_PASSWORD, findPasswordSaga);
+}
+
+// reducer
+const initialState = {
+  myEmail: {
+    email: ''
+  },
+  findIdRes: reducerUtils.initial(),
+  findQuestionRes: reducerUtils.initial(),
+  findPasswordRes: reducerUtils.initial()
+};
+
+export default handleActions(
+  {
+    [INITIALIZE_FORM]: (state, { payload: form }) => ({
+      ...state,
+      [form]: initialState[form]
+    }),
+    [CHANGE_FIELD]: (state, { payload: { form, key, value } }) =>
+      produce(state, draft => {
+        draft[form][key] = value;
+      }),
+    [FIND_ID]: state => ({
+      ...state,
+      findIdRes: reducerUtils.loading(state.findIdRes.data)
+    }),
+    [FIND_ID_SUCCESS]: (state, { payload: response }) => ({
+      ...state,
+      findIdRes: reducerUtils.success(response)
+    }),
+    [FIND_ID_FAILURE]: (state, { payload: error }) => ({
+      ...state,
+      findIdRes: reducerUtils.error(error)
+    }),
+    [FIND_QUESTION]: state => ({
+      ...state,
+      findQuestionRes: reducerUtils.loading(state.findQuestionRes.data)
+    }),
+    [FIND_QUESTION_SUCCESS]: (state, { payload: response }) => ({
+      ...state,
+      findQuestionRes: reducerUtils.success(response)
+    }),
+    [FIND_QUESTION_FAILURE]: (state, { payload: error }) => ({
+      ...state,
+      findQuestionRes: reducerUtils.error(error)
+    }),
+    [FIND_PASSWORD]: state => ({
+      ...state,
+      findPasswordRes: reducerUtils.loading(state.findPasswordRes.data)
+    }),
+    [FIND_PASSWORD_SUCCESS]: (state, { payload: response }) => ({
+      ...state,
+      findPasswordRes: reducerUtils.success(response)
+    }),
+    [FIND_PASSWORD_FAILURE]: (state, { payload: error }) => ({
+      ...state,
+      findPasswordRes: reducerUtils.error(error)
+    })
+  },
+  initialState
+);

--- a/src/modules/find/index.js
+++ b/src/modules/find/index.js
@@ -49,7 +49,7 @@ export const findPassword = createAction(
 
 // Sagas
 const findIdSaga = createRequestSaga(FIND_ID, api.findId);
-const findQuestionSaga = createRequestSaga(FIND_ID, api.findQuestion);
+const findQuestionSaga = createRequestSaga(FIND_QUESTION, api.findQuestion);
 const findPasswordSaga = createRequestSaga(FIND_PASSWORD, api.findPassword);
 
 export function* findSaga() {
@@ -60,8 +60,9 @@ export function* findSaga() {
 
 // reducer
 const initialState = {
-  myEmail: {
-    email: ''
+  myInfo: {
+    email: '',
+    userId: ''
   },
   findIdRes: reducerUtils.initial(),
   findQuestionRes: reducerUtils.initial(),

--- a/src/modules/find/index.js
+++ b/src/modules/find/index.js
@@ -62,7 +62,8 @@ export function* findSaga() {
 const initialState = {
   myInfo: {
     email: '',
-    userId: ''
+    userId: '',
+    answer: ''
   },
   findIdRes: reducerUtils.initial(),
   findQuestionRes: reducerUtils.initial(),

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux';
 import { all } from 'redux-saga/effects';
 import auth, { authSaga } from './auth';
 import account, { accountSaga } from './account';
+import find, { findSaga } from './find';
 import reply, { replySaga } from './reply';
 import post, { postSaga } from './post';
 import board, { boardSaga } from './board';
@@ -13,6 +14,7 @@ import feedback from './feedback';
 const rootReducer = combineReducers({
   auth,
   account,
+  find,
   post,
   board,
   reply,
@@ -26,6 +28,7 @@ export function* rootSaga() {
   yield all([
     authSaga(),
     accountSaga(),
+    findSaga(),
     postSaga(),
     boardSaga(),
     replySaga(),

--- a/src/pages/ForgotPage.js
+++ b/src/pages/ForgotPage.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import ForgotContainer from '../containers/Forgot/ForgotContainer';
+
+const ForgotPage = () => {
+  return <ForgotContainer />;
+};
+
+export default ForgotPage;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/40172373/140714408-39976ce5-e08a-4385-a80d-199cbae0e6d5.png)

비밀번호 찾기 기능에 이메일이 필요하기 때문에 비밀번호 찾는 과정을 
가입이메일로 아이디 찾기 -> 아이디로 내 질문 조회 -> 내 질문의 답을 순서대로 입력하게 만들었습니다 (전 단계를 수행해야 버튼이 열림)