### PR TITLE
[KIT-228] 헤더 반응형 처리 관련

### DIFF
--- a/src/components/Board/BoardHead.js
+++ b/src/components/Board/BoardHead.js
@@ -67,9 +67,7 @@ const BoardHead = props => {
     onSearch,
     onSearchChange,
     onWritePost,
-    boardDescription,
-    onSelectOpen,
-    onSelectClose
+    boardDescription
   } = props;
 
   return (
@@ -88,8 +86,6 @@ const BoardHead = props => {
           onPostSearchTypeChange={onPostSearchTypeChange}
           keyword={keyword}
           onSearchChange={onSearchChange}
-          onSelectOpen={onSelectOpen}
-          onSelectClose={onSelectClose}
         />
       </SearchBarForm>
 

--- a/src/components/Board/BoardSearch.js
+++ b/src/components/Board/BoardSearch.js
@@ -33,14 +33,8 @@ const ButtonStyled = styled(Button)`
 `;
 
 const BoardSearch = props => {
-  const {
-    postSearchType,
-    onPostSearchTypeChange,
-    keyword,
-    onSearchChange,
-    onSelectOpen,
-    onSelectClose
-  } = props;
+  const { postSearchType, onPostSearchTypeChange, keyword, onSearchChange } =
+    props;
 
   return (
     <>
@@ -49,8 +43,6 @@ const BoardSearch = props => {
         value={postSearchType}
         onChange={onPostSearchTypeChange}
         variant="standard"
-        onOpen={onSelectOpen}
-        onClose={onSelectClose}
       >
         {postSearchTypeList.map(type => (
           <MenuItem value={type.type} key={type.type}>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,21 +1,22 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Link, NavLink } from 'react-router-dom';
-import { CircularProgress } from '@mui/material';
+import { AppBar, CircularProgress } from '@mui/material';
 import { faBars, faSearch } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import LoginDialogContainer from '../../containers/LoginDialog/LoginDialogContainer';
-import { isMobile } from '../../utils/format';
 import BoardSearchDialog from './BoardSearchDialog';
 
-const HeaderWraper = styled.header`
+const HeaderWraper = styled(AppBar)`
   width: 100%;
   min-height: 80px;
   position: fixed;
   display: flex;
   justify-content: center;
+  flex-direction: row;
   box-shadow: rgba(149, 157, 165, 0.2) 0px 2px 6px;
   background: ${({ theme }) => theme.themeColor.bgColor};
+  color: #000000;
   z-index: 10;
   @media ${({ theme }) => theme.sizeQuery.mobile} {
     min-height: 60px;
@@ -28,8 +29,6 @@ const NavigationWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-right: ${props =>
-    props.isPopoverOpen && !isMobile() ? '17px' : null};
   width: ${({ theme }) => theme.size.tablet};
   @media ${({ theme }) => theme.sizeQuery.tablet} {
     width: ${({ theme }) => theme.size.mobile};
@@ -326,8 +325,7 @@ const Header = props => {
     handleMenuOpen,
     handleMenuClose,
     handleSearchOpen,
-    handleSearchClose,
-    isPopoverOpen
+    handleSearchClose
   } = props;
 
   const handleMobileMenuOpen = () =>
@@ -341,8 +339,8 @@ const Header = props => {
 
   return (
     <>
-      <HeaderWraper>
-        <NavigationWrapper isPopoverOpen={isPopoverOpen}>
+      <HeaderWraper position="fixed">
+        <NavigationWrapper>
           <LeftNavWrapper>
             <Logo to="/">SE Board</Logo>
             <Menu data={data} />

--- a/src/components/Post/Post.js
+++ b/src/components/Post/Post.js
@@ -34,7 +34,8 @@ const NoBoardBox = styled.div`
   margin-top: 196px;
 `;
 
-const PostHead = styled.div`
+const PostHeaderWrapper = styled.div`
+  width: 100%;
   padding: 1rem 0.5rem;
 `;
 
@@ -63,7 +64,8 @@ const AnonymousIcon = styled.span`
   margin: 0px 0.3rem;
 `;
 
-const PostText = styled.div`
+const EditorOutputWrapper = styled.div`
+  width: 100%;
   padding: 3rem 0.6em;
   font-size: 1rem;
   border-top: 1px solid #cccccc;
@@ -159,68 +161,66 @@ const PostHeaderInfo = props => {
   }
 
   return (
-    <>
-      <PostHeadInfo>
+    <PostHeadInfo>
+      <PostHeadInfoComponent>
+        {accountIdString ? (
+          <WriterIcon onClick={menuClick} id="writer">
+            <Icon icon={faUser} />
+            {nickname}
+          </WriterIcon>
+        ) : (
+          <AnonymousIcon id="writer">
+            <Icon icon={faUser} />
+            {nickname}
+          </AnonymousIcon>
+        )}
+        <Menu
+          anchorEl={writerEl}
+          keepMounted
+          open={Boolean(writerEl)}
+          onClose={menuClick}
+          style={{ marginLeft: '4rem' }}
+        >
+          {menuItem('writer')}
+        </Menu>
+        <PostHeadInfoComponent>{writeTime}</PostHeadInfoComponent>
         <PostHeadInfoComponent>
-          {accountIdString ? (
-            <WriterIcon onClick={menuClick} id="writer">
-              <Icon icon={faUser} />
-              {nickname}
-            </WriterIcon>
-          ) : (
-            <AnonymousIcon id="writer">
-              <Icon icon={faUser} />
-              {nickname}
-            </AnonymousIcon>
-          )}
-          <Menu
-            anchorEl={writerEl}
-            keepMounted
-            open={Boolean(writerEl)}
-            onClose={menuClick}
-            style={{ marginLeft: '4rem' }}
-          >
-            {menuItem('writer')}
-          </Menu>
-          <PostHeadInfoComponent>{writeTime}</PostHeadInfoComponent>
+          <Icon icon={faEye} />
+          {views}
+        </PostHeadInfoComponent>
+        {isNotice === 'NORMAL' ? (
+          <></>
+        ) : (
           <PostHeadInfoComponent>
-            <Icon icon={faEye} />
-            {views}
+            <Icon icon={faFlag} />
           </PostHeadInfoComponent>
-          {isNotice === 'NORMAL' ? (
-            <></>
-          ) : (
-            <PostHeadInfoComponent>
-              <Icon icon={faFlag} />
-            </PostHeadInfoComponent>
-          )}
-          {isSecret === 'NORMAL' ? (
-            <></>
-          ) : (
-            <PostHeadInfoComponent>
-              <Icon icon={faLock} />
-            </PostHeadInfoComponent>
-          )}
-        </PostHeadInfoComponent>
-        <PostHeadInfoComponent>
-          <MoreButton
-            icon={faEllipsisH}
-            size="lg"
-            onClick={menuClick}
-            id="more"
-          />
-          <Menu
-            anchorEl={moremenuEl}
-            keepMounted
-            open={Boolean(moremenuEl)}
-            onClose={menuClick}
-            style={{ marginLeft: '1.75rem' }}
-          >
-            {menuItem('menu')}
-          </Menu>
-        </PostHeadInfoComponent>
-      </PostHeadInfo>
-    </>
+        )}
+        {isSecret === 'NORMAL' ? (
+          <></>
+        ) : (
+          <PostHeadInfoComponent>
+            <Icon icon={faLock} />
+          </PostHeadInfoComponent>
+        )}
+      </PostHeadInfoComponent>
+      <PostHeadInfoComponent>
+        <MoreButton
+          icon={faEllipsisH}
+          size="lg"
+          onClick={menuClick}
+          id="more"
+        />
+        <Menu
+          anchorEl={moremenuEl}
+          keepMounted
+          open={Boolean(moremenuEl)}
+          onClose={menuClick}
+          style={{ marginLeft: '1.75rem' }}
+        >
+          {menuItem('menu')}
+        </Menu>
+      </PostHeadInfoComponent>
+    </PostHeadInfo>
   );
 };
 
@@ -239,7 +239,7 @@ const PostHeader = props => {
   } = res;
   const writeTime = `${createdAt[0]}년${createdAt[1]}월${createdAt[2]}일 ${createdAt[3]}:${createdAt[4]}`;
   return (
-    <PostHead>
+    <PostHeaderWrapper>
       <PostHeadTitle>
         {postContent.title}
         <Tags tags={tags} />
@@ -257,7 +257,7 @@ const PostHeader = props => {
         menuClick={menuClick}
         functionExcute={functionExcute}
       />
-    </PostHead>
+    </PostHeaderWrapper>
   );
 };
 
@@ -268,9 +268,9 @@ const PostMain = props => {
     return { __html: getEncodeHTML(postContent.text) };
   };
   return (
-    <PostText>
+    <EditorOutputWrapper>
       <EditorOutput content={handleContent()} />
-    </PostText>
+    </EditorOutputWrapper>
   );
 };
 

--- a/src/components/Post/PostAdd.js
+++ b/src/components/Post/PostAdd.js
@@ -19,6 +19,19 @@ const Wrapper = styled.div`
   }
 `;
 
+const ContentWrapper = styled.div`
+  width: 100%;
+  padding: 2rem;
+  flex-direction: column;
+  align-items: center;
+  background-color: #ffffff;
+  box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
+  @media ${props => props.theme.mobile} {
+    width: calc(100% - 1rem);
+    padding: 0.5rem;
+  }
+`;
+
 const TitleInput = styled.input`
   width: 100%;
   font-size: 1.5rem;
@@ -199,7 +212,7 @@ const PostAdd = props => {
     errorMessageProps
   } = props;
   return (
-    <>
+    <ContentWrapper>
       <PostTitle {...postTitleProps} />
       <PostTagAdd {...postTagAddProps} />
       <Editor {...editorProps} />
@@ -208,7 +221,7 @@ const PostAdd = props => {
       <AttachList {...attachListProps} />
       <PostAddFooter {...postAddFooterProps} />
       <ErrorMessage {...errorMessageProps} />
-    </>
+    </ContentWrapper>
   );
 };
 

--- a/src/components/Post/PostUpdate.js
+++ b/src/components/Post/PostUpdate.js
@@ -19,6 +19,19 @@ const Wrapper = styled.div`
   }
 `;
 
+const ContentWrapper = styled.div`
+  width: 100%;
+  padding: 2rem;
+  flex-direction: column;
+  align-items: center;
+  background-color: #ffffff;
+  box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
+  @media ${props => props.theme.mobile} {
+    width: calc(100% - 1rem);
+    padding: 0.5rem;
+  }
+`;
+
 const TitleInput = styled.input`
   width: 100%;
   font-size: 1.5rem;
@@ -188,7 +201,7 @@ const PostUpdate = props => {
     errorMessageProps
   } = props;
   return (
-    <>
+    <ContentWrapper>
       <PostTitle {...postTitleProps} />
       {postTagAddProps.isAccountPost && <PostTagAdd {...postTagAddProps} />}
       {editorProps.data && <Editor {...editorProps} />}
@@ -197,7 +210,7 @@ const PostUpdate = props => {
       <AttachList {...attachListProps} />
       <PostUpdateFooter {...postUpdateFooterProps} />
       <ErrorMessage {...errorMessageProps} />
-    </>
+    </ContentWrapper>
   );
 };
 

--- a/src/containers/Board/BoardHeadContainer.js
+++ b/src/containers/Board/BoardHeadContainer.js
@@ -3,7 +3,6 @@ import qs from 'qs';
 import { useDispatch, useSelector } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { searchPost } from '../../modules/board';
-import { isPopoverOpen, isPopoverClose } from '../../modules/styles';
 import BoardHead from '../../components/Board/BoardHead';
 
 const BoardHeadContainer = props => {
@@ -82,14 +81,6 @@ const BoardHeadContainer = props => {
     history.push(`/board/${match.params.boardNameEng}/write`);
   };
 
-  const onSelectOpen = () => {
-    dispatch(isPopoverOpen());
-  };
-
-  const onSelectClose = () => {
-    dispatch(isPopoverClose());
-  };
-
   return (
     <BoardHead
       boardDescription={boardDescription}
@@ -99,8 +90,6 @@ const BoardHeadContainer = props => {
       onSearch={onSearch}
       onSearchChange={onSearchChange}
       onWritePost={onWritePost}
-      onSelectOpen={onSelectOpen}
-      onSelectClose={onSelectClose}
       onPostSearchTypeChange={onPostSearchTypeChange}
     />
   );

--- a/src/containers/Header/HeaderContainer.js
+++ b/src/containers/Header/HeaderContainer.js
@@ -7,14 +7,11 @@ import Header from '../../components/Header/Header';
 const HeaderContainer = props => {
   const { location } = props;
   const dispatch = useDispatch();
-  const { data, loading, signin, isPopoverOpen } = useSelector(
-    ({ menu, auth, styles }) => ({
-      data: menu.loadedMenuList.data,
-      loading: menu.loadedMenuList.loading,
-      signin: auth.auth.data,
-      isPopoverOpen: styles.isPopoverOpen
-    })
-  );
+  const { data, loading, signin } = useSelector(({ menu, auth }) => ({
+    data: menu.loadedMenuList.data,
+    loading: menu.loadedMenuList.loading,
+    signin: auth.auth.data
+  }));
   const [menuOpen, setMenuOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
 
@@ -52,7 +49,6 @@ const HeaderContainer = props => {
       handleMenuClose={handleMenuClose}
       handleSearchOpen={handleSearchOpen}
       handleSearchClose={handleSearchClose}
-      isPopoverOpen={isPopoverOpen}
     />
   );
 };

--- a/src/modules/styles/index.js
+++ b/src/modules/styles/index.js
@@ -3,14 +3,10 @@ import { createAction, handleActions } from 'redux-actions';
 // Actions
 const IS_DARK_MODE_ON = 'styles/IS_DARK_MODE_ON';
 const IS_DARK_MODE_OFF = 'styles/IS_DARK_MODE_OFF';
-const IS_SELECT_OPEN = 'styles/IS_SELECT_OPEN';
-const IS_SELECT_CLOSE = 'styles/IS_SELECT_CLOSE';
 
 // Action Creators
 export const isDarkModeOn = createAction(IS_DARK_MODE_ON);
 export const isDarkModeOff = createAction(IS_DARK_MODE_OFF);
-export const isPopoverOpen = createAction(IS_SELECT_OPEN);
-export const isPopoverClose = createAction(IS_SELECT_CLOSE);
 
 // Sagas
 
@@ -29,14 +25,6 @@ export default handleActions(
     [IS_DARK_MODE_OFF]: () => ({
       ...initialState,
       themeMode: 'LIGHT'
-    }),
-    [IS_SELECT_CLOSE]: () => ({
-      ...initialState,
-      isPopoverOpen: false
-    }),
-    [IS_SELECT_OPEN]: () => ({
-      ...initialState,
-      isPopoverOpen: true
     })
   },
   initialState

--- a/src/pages/PostPage.js
+++ b/src/pages/PostPage.js
@@ -1,26 +1,10 @@
 import React from 'react';
-import styled from 'styled-components';
+import { MainWrapper } from '../components/Common/Wrapper/Wrapper';
 import BoardHeadContainer from '../containers/Board/BoardHeadContainer';
 import BoardPaginationContainer from '../containers/Board/BoardPaginationContainer';
 import BoardPostListContainer from '../containers/Board/BoardPostListContainer';
 import PostContainer from '../containers/Post/PostContainer';
 
-const MainWrapper = styled.div`
-  margin: auto;
-  margin-top: 3rem;
-  width: 70vw;
-  max-width: 100%;
-  padding: 1.5rem;
-  display: display;
-  align-items: center;
-  background-color: #ffffff;
-  box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
-  @media ${props => props.theme.mobile} {
-    width: calc(100vw - 1rem);
-    margin-top: 1rem;
-    padding: 0;
-  }
-`;
 const PostPage = () => {
   return (
     <>

--- a/src/pages/PostUpdatePage.js
+++ b/src/pages/PostUpdatePage.js
@@ -1,38 +1,11 @@
 import React from 'react';
-import styled from 'styled-components';
+import { MainWrapper } from '../components/Common/Wrapper/Wrapper';
 import PostUpdateContainer from '../containers/Post/PostUpdateContainer';
-
-const ContentWrapper = styled.div`
-  margin-top: 3rem;
-  width: calc(100% - 4rem);
-  padding: 2rem;
-  flex-direction: column;
-  align-items: center;
-  background-color: #ffffff;
-  box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
-  @media ${props => props.theme.mobile} {
-    width: calc(100% - 1rem);
-    padding: 0.5rem;
-  }
-`;
-
-const MainWrapper = styled.div`
-  margin: auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 70vw;
-  @media ${props => props.theme.mobile} {
-    width: 100vw;
-  }
-`;
 
 const PostWritePage = () => {
   return (
     <MainWrapper>
-      <ContentWrapper>
-        <PostUpdateContainer />
-      </ContentWrapper>
+      <PostUpdateContainer />
     </MainWrapper>
   );
 };

--- a/src/pages/PostWritePage.js
+++ b/src/pages/PostWritePage.js
@@ -1,38 +1,11 @@
 import React from 'react';
-import styled from 'styled-components';
+import { MainWrapper } from '../components/Common/Wrapper/Wrapper';
 import PostAddContainer from '../containers/Post/PostAddContainer';
-
-const ContentWrapper = styled.div`
-  margin-top: 3rem;
-  width: calc(100% - 4rem);
-  padding: 2rem;
-  flex-direction: column;
-  align-items: center;
-  background-color: #ffffff;
-  box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
-  @media ${props => props.theme.mobile} {
-    width: calc(100% - 1rem);
-    padding: 0.5rem;
-  }
-`;
-
-const MainWrapper = styled.div`
-  margin: auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 70vw;
-  @media ${props => props.theme.mobile} {
-    width: 100vw;
-  }
-`;
 
 const PostWritePage = () => {
   return (
     <MainWrapper>
-      <ContentWrapper>
-        <PostAddContainer />
-      </ContentWrapper>
+      <PostAddContainer />
     </MainWrapper>
   );
 };


### PR DESCRIPTION
- 헤더부분 div를 mui appbar로 변경 
  - overflow-y scrollbar가 존재할 때, Dialog, Select 등을 사용 시 body
  태그 styled에 padding-right: 17px; overflow: hidden; 생성되는데 Mui의
  AppBar를 사용하면 자동으로 처리해줌
  - 이전에는 store에 클릭 유무 + 모바일 환경으로 처리했는데 이러면
  스크롤 바가 없는 상태에서 또 다시 padding 차이 발생
  - 결론: DOM 에서 height 계산하면 가능할 것 같은데 일일이 특정 상황 찾아
  집어넣기 헷갈릴 것 같아서 뺌
![image](https://user-images.githubusercontent.com/65995108/141111713-1a232623-a452-445b-81bc-704b6cc639fd.png)
![image](https://user-images.githubusercontent.com/65995108/141111769-d1a1f406-687d-48c3-95e3-776ea2062b36.png)
- div 사용
![image](https://user-images.githubusercontent.com/65995108/141111958-025f0077-9d93-477e-9e79-7560c9989e44.png)
- AppBar 사용
![image](https://user-images.githubusercontent.com/65995108/141112038-b0fb0444-2524-4df9-9879-849fc5423ffd.png)